### PR TITLE
Add handling of comments in targets.txt

### DIFF
--- a/lib/targets.go
+++ b/lib/targets.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-  "regexp"
 	"math/rand"
 	"net/http"
 	"os"
@@ -31,8 +30,8 @@ func readTargets(source io.Reader) (Targets, error) {
 	for scanner.Scan() {
 		line := scanner.Text()
 
-		if !skipLine(line) { // Not a comment or blank line
-      lines = append(lines, line)
+		if line = strings.TrimSpace(line); line != "" && line[0:2] != "//" { // A comment or blank line
+			lines = append(lines, line)
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -40,10 +39,6 @@ func readTargets(source io.Reader) (Targets, error) {
 	}
 
 	return NewTargets(lines)
-}
-
-func skipLine(line string) (bool) {
-  return regexp.MustCompile(`^\s*((\/\/)|$)`).MatchString(line)
 }
 
 // NewTargets instantiates Targets from a slice of strings

--- a/lib/targets_test.go
+++ b/lib/targets_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestReadTargets(t *testing.T) {
-  lines := bytes.NewBufferString("GET http://lolcathost:9999/\n\n      // HEAD http://lolcathost.com this is a comment \nHEAD http://lolcathost:9999/\n")
+	lines := bytes.NewBufferString("GET http://lolcathost:9999/\n\n      // HEAD http://lolcathost.com this is a comment \nHEAD http://lolcathost:9999/\n")
 	targets, err := readTargets(lines)
 	if err != nil {
 		t.Fatalf("Couldn't parse valid source: %s", err)


### PR DESCRIPTION
Skips lines that start with `//`, to allow commments in `targets.txt`. This is 
handy when you want to attach a comment on why a specific endpoint is tested,
in a `targets.txt` used as part of a benchmark suite.
