### PR TITLE
Suport a curl -k mode?

### DIFF
--- a/lib/attack.go
+++ b/lib/attack.go
@@ -1,6 +1,7 @@
 package vegeta
 
 import (
+	"crypto/tls"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -39,12 +40,20 @@ func drill(rate uint64, reqs chan *http.Request, res chan Result) {
 	}
 }
 
+var client = &http.Client{
+	Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	},
+}
+
 // hit executes the passed http.Request and puts the result into results.
 // Both transport errors and unsucessfull requests (non {2xx,3xx}) are
 // considered errors.
 func hit(req *http.Request, res chan Result) {
 	began := time.Now()
-	r, err := http.DefaultClient.Do(req)
+	r, err := client.Do(req)
 	result := Result{
 		Timestamp: began,
 		Timing:    time.Since(began),

--- a/lib/attack_test.go
+++ b/lib/attack_test.go
@@ -3,6 +3,7 @@ package vegeta
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -20,5 +21,18 @@ func TestAttackRate(t *testing.T) {
 	Attack(Targets{request}, rate, 1*time.Second)
 	if hits := atomic.LoadUint64(&hitCount); hits != rate {
 		t.Fatalf("Wrong number of hits: want %d, got %d\n", rate, hits)
+	}
+}
+
+func TestClientCertConfig(t *testing.T) {
+	server := httptest.NewTLSServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}),
+	)
+	request, _ := http.NewRequest("GET", server.URL, nil)
+	results := make(chan Result, 1)
+	hit(request, results)
+	result := <-results
+	if strings.Contains(result.Error, "x509: certificate signed by unknown authority") {
+		t.Errorf("Invalid certificates should be ignored: Got `%s`", result.Error)
 	}
 }


### PR DESCRIPTION
Is there an arg or can one be added that does the equivalent of curl -k , that is, not doing cert validation on https requests?
