### PR TITLE
add download button to plot renderer

### DIFF
--- a/lib/reporters.go
+++ b/lib/reporters.go
@@ -66,7 +66,7 @@ var plotsTemplate = `<!doctype>
 </head>
 <body>
   <div id="latencies" style="font-family: Courier; width: 100%%; height: 600px"></div>
-  <a href="#" download="vegetaplot.png" onclick="this.href = document.getElementsByTagName('canvas')[0].toDataURL('image/png').replace(/^data:image\/[^;]/, 'data:application/octet-stream')">Download as png</a>
+  <a href="#" download="vegetaplot.png" onclick="this.href = document.getElementsByTagName('canvas')[0].toDataURL('image/png').replace(/^data:image\/[^;]/, 'data:application/octet-stream')">Download as PNG</a>
   <script>
 	%s
   </script>


### PR DESCRIPTION
So people can download (at least) the canvas image.
X and Y axis labels are not included. This is more a hack then a actual implementation. But it works! But it show that this is possible.

refs #39
