### PR TITLE
The Dygraph labels "OK" and "ERROR" were backwards

### DIFF
--- a/lib/reporters.go
+++ b/lib/reporters.go
@@ -87,7 +87,7 @@ const plotsTemplate = `<!doctype>
     [%s],
     {
       title: 'Vegeta Plot',
-      labels: ['Seconds', 'OK', 'ERR'],
+      labels: ['Seconds', 'ERR', 'OK'],
       ylabel: 'Latency (ms)',
       xlabel: 'Seconds elapsed',
       showRoller: true,


### PR DESCRIPTION
![screen shot 2014-04-21 at 1 18 56 pm](https://cloud.githubusercontent.com/assets/3129677/2758517/3ab19d12-c992-11e3-83f5-d35214555b30.png)

The OK data points were incorrectly labeled as ERR and vice-versa.
