### PR TITLE
NewMetrics panics if it receives an empty slice of results

### DIFF
--- a/lib/metrics_test.go
+++ b/lib/metrics_test.go
@@ -56,3 +56,7 @@ func TestNewMetrics(t *testing.T) {
 		t.Errorf("Errors: want: %v, got: %v", []string{err}, m.Errors)
 	}
 }
+
+func TestNewMetricsEmptyResults(t *testing.T) {
+  _ = NewMetrics([]Result{})
+}


### PR DESCRIPTION
When `NewMetrics` is called with an empty slice of results it panics with the following error:

```
panic: runtime error: index out of range

goroutine 15 [running]:
runtime.panic(0x28dbc0, 0x5d75b7)
    /usr/local/Cellar/go/1.2.1/libexec/src/pkg/runtime/panic.c:266 +0xb6
testing.func·005()
    /usr/local/Cellar/go/1.2.1/libexec/src/pkg/testing/testing.go:385 +0xe8
runtime.panic(0x28dbc0, 0x5d75b7)
    /usr/local/Cellar/go/1.2.1/libexec/src/pkg/runtime/panic.c:248 +0x106
github.com/xla/vegeta/lib.NewMetrics(0x11a5f38, 0x0, 0x0, 0x11a5f60)
    /Users/alx/dev/src/github.com/xla/vegeta/lib/metrics.go:65 +0x7bd
```

I added a stub test for the behaviour.
