### PR TITLE
fix: attacker must close request body

### DIFF
--- a/lib/attack.go
+++ b/lib/attack.go
@@ -109,6 +109,7 @@ func (a *Attacker) hit(tr Targeter) *Result {
 		res.Error = err.Error()
 		return res
 	}
+	defer r.Body.Close()
 
 	res.BytesOut = uint64(req.ContentLength)
 	res.Code = uint16(r.StatusCode)


### PR DESCRIPTION
The client must close the response body. That is why I am receiving too many open files error after 1024 req

http://golang.org/pkg/net/http/#Client.Do
