### PR TITLE
Metrics: Compute target processing time.

### DIFF
--- a/lib/metrics.go
+++ b/lib/metrics.go
@@ -29,6 +29,7 @@ type Metrics struct {
 	} `json:"bytes_out"`
 
 	Duration    time.Duration  `json:"duration"`
+	Processing  time.Duration  `json:"processing"`
 	Requests    uint64         `json:"requests"`
 	Success     float64        `json:"success"`
 	StatusCodes map[string]int `json:"status_codes"`
@@ -66,6 +67,7 @@ func NewMetrics(r Results) *Metrics {
 
 	m.Requests = uint64(len(r))
 	m.Duration = r[len(r)-1].Timestamp.Sub(r[0].Timestamp)
+	m.Processing = m.Duration + r[len(r)-1].Latency
 	m.Latencies.Mean = time.Duration(float64(totalLatencies) / float64(m.Requests))
 	m.Latencies.P50 = time.Duration(quants.Query(0.50))
 	m.Latencies.P95 = time.Duration(quants.Query(0.95))

--- a/lib/reporters.go
+++ b/lib/reporters.go
@@ -21,6 +21,7 @@ func ReportText(r Results) ([]byte, error) {
 	w := tabwriter.NewWriter(out, 0, 8, 2, '\t', tabwriter.StripEscape)
 	fmt.Fprintf(w, "Requests\t[total]\t%d\n", m.Requests)
 	fmt.Fprintf(w, "Duration\t[total]\t%s\n", m.Duration)
+	fmt.Fprintf(w, "Processing\t[total]\t%s\n", m.Processing)
 	fmt.Fprintf(w, "Latencies\t[mean, 50, 95, 99, max]\t%s, %s, %s, %s, %s\n",
 		m.Latencies.Mean, m.Latencies.P50, m.Latencies.P95, m.Latencies.P99, m.Latencies.Max)
 	fmt.Fprintf(w, "Bytes In\t[total, mean]\t%d, %.2f\n", m.BytesIn.Total, m.BytesIn.Mean)


### PR DESCRIPTION
While first testing Vegeta, I was a bit confused to see on the `ReportText` a constant duration time even though the processing time on my target server was growing.

I'd like to add a `Processing` duration  to have the actual target processing time in `Metrics`. It may be useful and less confusing to next new Vegeta players :)

Rgds,
