### PR TITLE
Add the ability to bucket results by latency

### DIFF
--- a/lib/metrics_test.go
+++ b/lib/metrics_test.go
@@ -12,7 +12,7 @@ func TestNewMetrics(t *testing.T) {
 		Result{500, time.Unix(0, 0), 100 * time.Millisecond, 10, 30, "Internal server error"},
 		Result{200, time.Unix(1, 0), 20 * time.Millisecond, 20, 20, ""},
 		Result{200, time.Unix(2, 0), 30 * time.Millisecond, 30, 10, ""},
-	})
+	}, nil)
 
 	for field, values := range map[string][]float64{
 		"BytesIn.Mean":  []float64{m.BytesIn.Mean, 20.0},
@@ -58,5 +58,5 @@ func TestNewMetrics(t *testing.T) {
 }
 
 func TestNewMetricsEmptyResults(t *testing.T) {
-	_ = NewMetrics([]Result{}) // Must not panic
+	_ = NewMetrics([]Result{}, nil) // Must not panic
 }

--- a/lib/reporters_test.go
+++ b/lib/reporters_test.go
@@ -20,6 +20,6 @@ func BenchmarkReportPlot(b *testing.B) {
 	// Start benchmark
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		ReportPlot(results)
+		ReportPlot(results, nil)
 	}
 }


### PR DESCRIPTION
I find it very useful to visualize load testing results as a histogram showing how many responses were received within various time buckets. Even better if the resulting graph is a [Pareto chart](https://en.wikipedia.org/wiki/Pareto_chart), showing me both the counts in each latency bucket as well as the cumulative total at or before each range. So I added a feature to vegeta to do this.

I don't think this is quite ready for merge. Most of the new stuff isn't tested, and I made some changes in this version to the interface for `NewMetrics()`, which you probably don't want to do.

Basically I'm submitting it now to see if this is a feature you'd consider merging, and to get your feedback on the approach & interface for this feature. If so, we can work to get it to a point where you'd want to merge it :)

At the very least, I'll need to rebase it on the current master.
