### PR TITLE
Support for per-target headers and body contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Usage of vegeta attack:
 ```
 
 #### -body
-Specifies the file whose content will be set as the body of every request.
+Specifies the file whose content will be set as the body of every
+request unless overridden per attack target, see `-targets`.
 
 #### -cert
 Specifies the x509 TLS certificate to be used with HTTPS requests.
@@ -90,8 +91,9 @@ The actual run time of the test can be longer than specified due to the
 responses delay.
 
 #### -header
-Specifies a request header to be used in all targets defined.
-You can specify as many as needed by repeating the flag.
+Specifies a request header to be used in all targets defined unless overridden
+per attack target, see `-targets`.  You can specify as many as needed by
+repeating the flag.
 
 #### -keepalive
 Specifies whether to reuse TCP connections between HTTP requests.
@@ -120,12 +122,30 @@ default is 10.
 
 #### -targets
 Specifies the attack targets in a line separated file, defaulting to stdin.
-The format should be as follows.
+The format should be as follows, combining any or all of the following:
+
+Simple targets
 ```
 GET http://goku:9090/path/to/dragon?item=balls
 GET http://user:password@goku:9090/path/to
 HEAD http://goku:9090/path/to/success
-...
+```
+
+Targets with custom headers (note the embedded [SPACE] representing a space in the header value)
+```
+GET http://user:password@goku:9090/path/to -HAccount-ID:8675309
+DELETE http://goku:9090/path/to/remove -HConfirmation-Token:90215 -HAuthorization:Token[SPACE]DEADBEEF
+```
+
+Targets with custom bodies
+```
+POST http://goku:9090/things <path/to/post_body.txt
+PATCH http://goku:9090/thingy/71988591 <path/to/patch_body.json
+```
+
+Targets with custom bodies and headers
+```
+POST http://goku:9090/things <path/to/post_body.txt -HAccount-ID:99
 ```
 
 #### -timeout

--- a/lib/targets.go
+++ b/lib/targets.go
@@ -6,7 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
+	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 )
@@ -38,6 +41,7 @@ func (t *Target) Request() (*http.Request, error) {
 
 // ErrNoTargets is returned when not enough Targets are available.
 var ErrNoTargets = errors.New("no targets to attack")
+var ErrNoBody = errors.New("No body referenced by file")
 
 // Targeter is a generator function which returns a new Target
 // or an error on every invocation. It is safe for concurrent use.
@@ -88,20 +92,88 @@ func NewLazyTargeter(src io.Reader, body []byte, hdr http.Header) Targeter {
 		for sc.Scan() {
 			line := bytes.TrimSpace(sc.Bytes())
 			if len(line) == 0 || bytes.HasPrefix(line, []byte("//")) {
-				// Skipping comments or blank lines
-				continue
+				continue // skip comments or blank lines
 			}
 			ps := bytes.Split(line, []byte(" "))
-			if len(ps) != 2 {
+			if len(ps) < 2 {
 				return nil, fmt.Errorf("invalid target: `%s`", line)
 			}
+
+			method := string(ps[0])
+			url := string(ps[1])
+
+			var (
+				err       error
+				useBody   []byte
+				useHeader http.Header
+			)
+
+			// Standard target - {METHOD} {url} + body + header from params
+			if len(ps) == 2 {
+				useBody = body
+				useHeader = hdr
+
+				// Enhanced target:
+				//   Headers only, including one with an embedded space:
+				//     GET {url} -HFoo:Bar -HX-Do-Not-Do:true -HSome-Name:Token[SPACE]ABCDEFG
+				//   Headers + body file reference
+				//     POST {url} -HFlavor:Cotton-Candy -HContent-Type:application/json <post_data/foo.json
+				//   Body file reference only
+				//     PATCH {url} <patch_data/foo.json
+			} else {
+				if useBody, useHeader, err = augmentTarget(ps[2:], body, hdr); err != nil {
+					continue
+				}
+			}
 			return &Target{
-				Method: string(ps[0]),
-				URL:    string(ps[1]),
-				Body:   body,
-				Header: hdr,
+				Method: method,
+				URL:    url,
+				Body:   useBody,
+				Header: useHeader,
 			}, nil
 		}
 		return nil, ErrNoTargets
 	}
+}
+
+func augmentTarget(additionalArgs [][]byte, body []byte, hdr http.Header) ([]byte, http.Header, error) {
+	targetHeaders := http.Header{}
+	for _, arg := range additionalArgs {
+		if bytes.HasPrefix(arg, []byte("-H")) {
+			pair := bytes.SplitN(arg[2:], []byte(":"), 2)
+			if len(pair) == 2 {
+				targetHeaders.Set(string(pair[0]), strings.Replace(string(pair[1]), "[SPACE]", " ", -1))
+			}
+		} else if bytes.HasPrefix(arg, []byte("<")) {
+			path := string(arg[1:])
+			if contents, err := slurp(strings.TrimSpace(path)); err != nil {
+				return nil, nil, ErrNoBody
+			} else {
+				body = *contents
+			}
+		}
+	}
+
+	// only use the new header object if we assigned any
+	// TODO: merge?
+	useHeader := targetHeaders
+	if len(targetHeaders) == 0 {
+		useHeader = hdr
+	}
+	return body, useHeader, nil
+}
+
+func slurp(path string) (*[]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		os.Stderr.WriteString(fmt.Sprintf("Skipping line, cannot open referenced file [Path: %s] [Error: %s]\n", path, err))
+		return nil, err
+	}
+	defer file.Close()
+	contents, err := ioutil.ReadAll(file)
+	if err != nil {
+		os.Stderr.WriteString(fmt.Sprintf("Skipping line, error reading referenced file [Path: %s] [Error: %s]\n", path, err))
+		return nil, err
+	}
+	return &contents, nil
 }

--- a/lib/targets_test.go
+++ b/lib/targets_test.go
@@ -3,9 +3,11 @@ package vegeta
 import (
 	"bytes"
 	"crypto/rand"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"reflect"
 	"testing"
 )
@@ -85,6 +87,90 @@ func TestNewLazyTarget(t *testing.T) {
 			URL:    "http://lolcathost:9999/",
 			Body:   body,
 			Header: hdr,
+		},
+		&Target{
+			Method: "HEAD",
+			URL:    "http://lolcathost:9999/",
+			Body:   body,
+			Header: hdr,
+		},
+	} {
+		if got, err := read(); err != nil {
+			t.Fatal(err)
+		} else if !reflect.DeepEqual(got, want) {
+			t.Errorf("got: %+v, want: %+v", got, want)
+		}
+	}
+
+	if got, err := read(); err != ErrNoTargets {
+		t.Fatalf("got: %v, want: %v", err, ErrNoTargets)
+	} else if got != nil {
+		t.Fatalf("got: %v, want: %v", got, nil)
+	}
+}
+
+func TestNewLazyExtendedTargetWithHeaders(t *testing.T) {
+	body, hdr := []byte("body"), http.Header{}
+	src := bytes.NewReader([]byte("GET http://lolcathost:9999/ -HAccept:application/json -HAccount-ID:Token[SPACE]12345\n// this is a comment \nHEAD http://lolcathost:9999/\n"))
+	read := NewLazyTargeter(src, body, hdr)
+
+	customHeader := http.Header{}
+	customHeader.Add("Accept", "application/json")
+	customHeader.Add("Account-ID", "Token 12345")
+
+	for _, want := range []*Target{
+		&Target{
+			Method: "GET",
+			URL:    "http://lolcathost:9999/",
+			Body:   body,
+			Header: customHeader,
+		},
+		&Target{
+			Method: "HEAD",
+			URL:    "http://lolcathost:9999/",
+			Body:   body,
+			Header: hdr,
+		},
+	} {
+		if got, err := read(); err != nil {
+			t.Fatal(err)
+		} else if !reflect.DeepEqual(got, want) {
+			t.Errorf("got: %+v, want: %+v", got, want)
+		}
+	}
+
+	if got, err := read(); err != ErrNoTargets {
+		t.Fatalf("got: %v, want: %v", err, ErrNoTargets)
+	} else if got != nil {
+		t.Fatalf("got: %v, want: %v", got, nil)
+	}
+}
+
+func TestNewLazyExtendedTargetWithHeadersAndContent(t *testing.T) {
+	body, hdr := []byte("body"), http.Header{}
+	contentFile := "test_post_data.txt"
+	src := bytes.NewReader([]byte(fmt.Sprintf(
+		"POST http://lolcathost:9999/ -HAccount-ID:Token[SPACE]12345[SPACE]FREDDY <%s\n// this is a comment \nHEAD http://lolcathost:9999/\n",
+		contentFile)))
+	read := NewLazyTargeter(src, body, hdr)
+
+	customHeader := http.Header{}
+	customHeader.Add("Account-ID", "Token 12345 FREDDY")
+	customBody := []byte("{\"someKey\": 8675309}")
+	f, err := os.Create(contentFile)
+	if err != nil {
+		t.Fatalf("Failed to create temporary file: %v", err)
+	}
+	defer os.Remove(f.Name())
+	f.Write(customBody)
+	f.Close()
+
+	for _, want := range []*Target{
+		&Target{
+			Method: "POST",
+			URL:    "http://lolcathost:9999/",
+			Body:   customBody,
+			Header: customHeader,
 		},
 		&Target{
 			Method: "HEAD",


### PR DESCRIPTION
Be able to specify headers and/or body contents per target, in addition to specifying them globally.

A few notes:
1. If a body file isn't found we skip the target
2. If we find any per-target headers we use none of the global headers. I didn't have a use case for this, but if it's useful to merge the global and per-target headers it's straightforward and I'd be happy to do so.
3. Yes, we're reading the full body for all the targets into memory. You can probably use the `-lazy` option if this is a big problem.
