### PR TITLE
Add interpolation settings to Targets

### DIFF
--- a/lib/attack_test.go
+++ b/lib/attack_test.go
@@ -21,7 +21,7 @@ func TestAttackRate(t *testing.T) {
 	rate := uint64(100)
 	atk := NewAttacker()
 	var hits uint64
-	for range atk.Attack(tr, rate, 1*time.Second) {
+	for _ = range atk.Attack(tr, rate, 1*time.Second) {
 		hits++
 	}
 	if got, want := hits, rate; got != want {

--- a/lib/interpolations.go
+++ b/lib/interpolations.go
@@ -1,0 +1,47 @@
+package vegeta
+
+import (
+	"math/rand"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// URLInterpolator interface, it must implement InterpolateURL that
+// should resolve the interpolation for the URL
+type URLInterpolator interface {
+	InterpolateURL(string) string
+}
+
+// BodyInterpolator interface, it must implement InterpolateBody that
+// should resolve the desired Body interpolation
+type BodyInterpolator interface {
+	InterpolateBody([]byte) []byte
+}
+
+// Simple random numeric Interpolation, it will randomize the specified Key
+// using the given Limit
+type RandomNumericInterpolation struct {
+	Key   string
+	Limit int
+	Rand  *rand.Rand
+}
+
+// RandomNumeric Request URL interpolation implementation
+func (interpolator *RandomNumericInterpolation) InterpolateURL(url string) string {
+	return interpolator.interpolatorReplace(url)
+}
+
+// RandomNumeric Request Body interpolation implementation
+func (interpolator *RandomNumericInterpolation) InterpolateBody(body []byte) []byte {
+	return []byte(interpolator.interpolatorReplace(string(body)))
+}
+
+// RandomNumeric generic Interpolator resolver
+func (interpolator *RandomNumericInterpolation) interpolatorReplace(content string) string {
+	if interpolator.Rand == nil {
+		interpolator.Rand = rand.New(rand.NewSource(time.Now().UTC().Unix()))
+	}
+
+	return strings.Replace(content, interpolator.Key, strconv.Itoa(interpolator.Rand.Intn(interpolator.Limit)), -1)
+}

--- a/lib/interpolations_test.go
+++ b/lib/interpolations_test.go
@@ -1,0 +1,73 @@
+package vegeta
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+)
+
+func TestInterpolatorReplace(t *testing.T) {
+	interpolation := RandomNumericInterpolation{
+		Key:   "{foo}",
+		Limit: int(^uint(0) >> 1),
+		Rand:  rand.New(rand.NewSource(1435875839)),
+	}
+
+	var stringTests = []struct {
+		Input  string
+		Output string
+	}{
+		{"https://foo.bar.com/api/{foo}/1", "https://foo.bar.com/api/2290778204292519845/1"},
+		{"https://foo.bar.com/api/{foo}/bar/{foo}", "https://foo.bar.com/api/9195823874823970824/bar/9195823874823970824"},
+	}
+
+	for _, stringTest := range stringTests {
+		if interpolation.interpolatorReplace(stringTest.Input) != stringTest.Output {
+			t.Error("The interpolation was not resolved sucessfully")
+		}
+	}
+}
+
+func TestInterpolateURL(t *testing.T) {
+	interpolation := RandomNumericInterpolation{
+		Key:   "{foo}",
+		Limit: int(^uint(0) >> 1),
+		Rand:  rand.New(rand.NewSource(1435875839)),
+	}
+
+	var urlTests = []struct {
+		Input  string
+		Output string
+	}{
+		{"https://foo.bar.com/api/{foo}/1", "https://foo.bar.com/api/2290778204292519845/1"},
+		{"https://foo.bar.com/api/{foo}/bar/{foo}", "https://foo.bar.com/api/9195823874823970824/bar/9195823874823970824"},
+	}
+
+	for _, urlTest := range urlTests {
+		if interpolation.InterpolateURL(urlTest.Input) != urlTest.Output {
+			t.Error("The URL interpolation was not resolved sucessfully")
+		}
+	}
+}
+
+func TestInterpolateBody(t *testing.T) {
+	interpolation := RandomNumericInterpolation{
+		Key:   "{foo}",
+		Limit: int(^uint(0) >> 1),
+		Rand:  rand.New(rand.NewSource(1435875839)),
+	}
+
+	var bodyTests = []struct {
+		Input  []byte
+		Output []byte
+	}{
+		{[]byte(`{"id": "{foo}", "value": "bar"}`), []byte(`{"id": "2290778204292519845", "value": "bar"}`)},
+		{[]byte(`{"id": "{foo}", "value": "{foo}"}`), []byte(`{"id": "9195823874823970824", "value": "9195823874823970824"}`)},
+	}
+
+	for _, bodyTest := range bodyTests {
+		if !bytes.Equal(interpolation.InterpolateBody(bodyTest.Input), bodyTest.Output) {
+			t.Error("The Body interpolation was not resolved sucessfully")
+		}
+	}
+}


### PR DESCRIPTION
After some vegeta loving, after using it to test REST services, i got the idea that it wasn't designed to perform user behaviour load testing. 

With that on mind, I felt a little bit frustrated when i couldn't attack endpoints that were only attackable once, like identified database record creators.

So i came with the idea about giving the option to specify randomized deterministic or not deterministic interpolators for the Request URL and Body, to be able to modify the URL and Body on every hit.

By seeding a rand to setup the `Target`, i could even test a different endpoint afterwards with the same values.

As it have been so useful to me, i wanted to share it.

Ex:

```golang
seed := time.Now().UTC().Unix()
randomizer := rand.New(rand.NewSource(seed))

vegeta.NewStaticTargeter(&vegeta.Target{
		Method: "POST",
		URL:    "http://localhost:3002/foo/{interpolated_id}/bar",
		Body:   []byte(`{foo": "{interpolated_id}", "foobar": 1}`),
		URLInterpolators: []vegeta.URLInterpolator{
			&vegeta.RandomNumericInterpolation{
				Key:   "{interpolated_id}",
				Limit: int(^uint(0) >> 1),
				Rand:  randomizer,
			},
		},
		BodyInterpolators: []vegeta.BodyInterpolator{
			&vegeta.RandomNumericInterpolation{
				Key:   "{interpolated_id}",
				Limit: int(^uint(0) >> 1),
				Rand:  randomizer,
			},
		},
	})
```