### PR TITLE
Use R's 8th method of quantile estimation for latencies

### DIFF
--- a/lib/metrics.go
+++ b/lib/metrics.go
@@ -1,50 +1,63 @@
 package vegeta
 
 import (
+	"math"
+	"sort"
 	"strconv"
 	"time"
-
-	"github.com/bmizerany/perks/quantile"
 )
 
-// Metrics holds the stats computed out of a slice of Results
-// that is used for some of the Reporters
-type Metrics struct {
-	Latencies struct {
+type (
+	// Metrics holds metrics computed out of a slice of Results which are used
+	// in some of the Reporters
+	Metrics struct {
+		// Latencies holds computed latency metrics.
+		Latencies LatencyMetrics `json:"latencies"`
+		// BytesIn holds computed incoming byte metrics.
+		BytesIn ByteMetrics `json:"bytes_in"`
+		// BytesOut holds computed outgoing byte metrics.
+		BytesOut ByteMetrics `json:"bytes_out"`
+		// Duration is the duration of the attack.
+		Duration time.Duration `json:"duration"`
+		// Wait is the extra time waiting for responses from targets.
+		Wait time.Duration `json:"wait"`
+		// Requests is the total number of requests executed.
+		Requests uint64 `json:"requests"`
+		// Rate is the rate of requests per second.
+		Rate float64 `json:"rate"`
+		// Success is the percentage of non-error responses.
+		Success float64 `json:"success"`
+		// StatusCodes is a histogram of the responses' status codes.
+		StatusCodes map[string]int `json:"status_codes"`
+		// Errors is a set of unique errors returned by the targets during the attack.
+		Errors []string `json:"errors"`
+	}
+
+	// LatencyMetrics holds computed request latency metrics.
+	LatencyMetrics struct {
+		// Mean is the mean request latency.
 		Mean time.Duration `json:"mean"`
-		P50  time.Duration `json:"50th"` // P50 is the 50th percentile upper value
-		P95  time.Duration `json:"95th"` // P95 is the 95th percentile upper value
-		P99  time.Duration `json:"99th"` // P99 is the 99th percentile upper value
-		Max  time.Duration `json:"max"`
-	} `json:"latencies"`
+		// P50 is the 50th percentile request latency.
+		P50 time.Duration `json:"50th"`
+		// P95 is the 95th percentile request latency.
+		P95 time.Duration `json:"95th"`
+		// P99 is the 99th percentile request latency.
+		P99 time.Duration `json:"99th"`
+		// Max is the maximum observed request latency.
+		Max time.Duration `json:"max"`
+	}
 
-	BytesIn struct {
-		Total uint64  `json:"total"`
-		Mean  float64 `json:"mean"`
-	} `json:"bytes_in"`
+	// ByteMetrics holds computed byte flow metrics.
+	ByteMetrics struct {
+		// Total is the total number of flowing bytes in an attack.
+		Total uint64 `json:"total"`
+		// Mean is the mean number of flowing bytes per hit.
+		Mean float64 `json:"mean"`
+	}
+)
 
-	BytesOut struct {
-		Total uint64  `json:"total"`
-		Mean  float64 `json:"mean"`
-	} `json:"bytes_out"`
-
-	// Duration is the duration of the attack.
-	Duration time.Duration `json:"duration"`
-	// Wait is the extra time waiting for responses from targets.
-	Wait time.Duration `json:"wait"`
-	// Requests is the total number of requests executed.
-	Requests uint64 `json:"requests"`
-	// Rate is the rate of requests per second.
-	Rate float64 `json:"rate"`
-	// Success is the percentage of non-error responses.
-	Success float64 `json:"success"`
-	// StatusCodes is a histogram of the responses' status codes.
-	StatusCodes map[string]int `json:"status_codes"`
-	// Errors is a set of unique errors returned by the targets during the attack.
-	Errors []string `json:"errors"`
-}
-
-// NewMetrics computes and returns a Metrics struct out of a slice of Results.
+// NewMetrics computes and returns a Metrics struct out of a slice of Results
+// pre-sorted by timestamp.
 func NewMetrics(r Results) *Metrics {
 	m := &Metrics{StatusCodes: map[string]int{}}
 
@@ -54,21 +67,18 @@ func NewMetrics(r Results) *Metrics {
 
 	var (
 		errorSet       = map[string]struct{}{}
-		quants         = quantile.NewTargeted(0.50, 0.95, 0.99)
+		latencies      = make([]float64, len(r))
 		totalSuccess   int
 		totalLatencies time.Duration
 		latest         time.Time
 	)
 
-	for _, result := range r {
-		quants.Insert(float64(result.Latency))
+	for i, result := range r {
+		latencies[i] = float64(result.Latency)
 		m.StatusCodes[strconv.Itoa(int(result.Code))]++
 		totalLatencies += result.Latency
 		m.BytesOut.Total += result.BytesOut
 		m.BytesIn.Total += result.BytesIn
-		if result.Latency > m.Latencies.Max {
-			m.Latencies.Max = result.Latency
-		}
 		if end := result.Timestamp.Add(result.Latency); end.After(latest) {
 			latest = end
 		}
@@ -85,12 +95,15 @@ func NewMetrics(r Results) *Metrics {
 	m.Rate = float64(m.Requests) / m.Duration.Seconds()
 	m.Wait = latest.Sub(r[len(r)-1].Timestamp)
 	m.Latencies.Mean = time.Duration(float64(totalLatencies) / float64(m.Requests))
-	m.Latencies.P50 = time.Duration(quants.Query(0.50))
-	m.Latencies.P95 = time.Duration(quants.Query(0.95))
-	m.Latencies.P99 = time.Duration(quants.Query(0.99))
 	m.BytesIn.Mean = float64(m.BytesIn.Total) / float64(m.Requests)
 	m.BytesOut.Mean = float64(m.BytesOut.Total) / float64(m.Requests)
 	m.Success = float64(totalSuccess) / float64(m.Requests)
+
+	sort.Float64s(latencies)
+	m.Latencies.P50 = time.Duration(.5 + quantileR8(0.50, latencies))
+	m.Latencies.P95 = time.Duration(.5 + quantileR8(0.95, latencies))
+	m.Latencies.P99 = time.Duration(.5 + quantileR8(0.99, latencies))
+	m.Latencies.Max = time.Duration(latencies[len(latencies)-1])
 
 	m.Errors = make([]string, 0, len(errorSet))
 	for err := range errorSet {
@@ -98,4 +111,41 @@ func NewMetrics(r Results) *Metrics {
 	}
 
 	return m
+}
+
+// quantileR8 computes the quantile p with R's type 8 estimation method.
+// The resulting quantile estimates are approximately median-unbiased
+// regardless of the distribution of x.
+func quantileR8(p float64, x []float64) float64 {
+	return quantile(p, 1/3.0, 1/3.0, x)
+}
+
+// quantile computes empirical quantiles for a slice of sorted float64s.
+// The implementation is an adaptation of scipy.stats.mstats.mquantiles. See:
+// http://docs.scipy.org/doc/scipy-0.15.1/reference/generated/scipy.stats.mstats.mquantiles.html
+func quantile(p, alphap, betap float64, x []float64) float64 {
+	switch len(x) {
+	case 0:
+		return 0
+	case 1:
+		return x[0]
+	}
+	m := alphap + p*(1-alphap-betap)
+	n := float64(len(x))
+	aleph := n*p + m
+	k := math.Floor(clip(aleph, 1, n-1))
+	gamma := clip(aleph-k, 0, 1)
+	return (1-gamma)*x[int(k)-1] + gamma*x[int(k)]
+}
+
+// clip clips a number n to the range [lo, hi]
+func clip(n, lo, hi float64) float64 {
+	switch {
+	case n < lo:
+		return lo
+	case n > hi:
+		return hi
+	default:
+		return n
+	}
 }

--- a/lib/metrics_test.go
+++ b/lib/metrics_test.go
@@ -1,6 +1,7 @@
 package vegeta
 
 import (
+	"reflect"
 	"testing"
 	"time"
 )
@@ -8,55 +9,40 @@ import (
 func TestNewMetrics(t *testing.T) {
 	t.Parallel()
 
-	m := NewMetrics(Results{
+	want := &Metrics{
+		Latencies: LatencyMetrics{
+			Mean: 112100000,
+			P50:  115000000,
+			P95:  200000000,
+			P99:  200000000,
+			Max:  200000000,
+		},
+		BytesIn:     ByteMetrics{Total: 170, Mean: 17.00},
+		BytesOut:    ByteMetrics{Total: 230, Mean: 23.00},
+		Duration:    9 * time.Second,
+		Wait:        190 * time.Millisecond,
+		Requests:    10,
+		Rate:        1.1111111111111112,
+		Success:     0.9,
+		StatusCodes: map[string]int{"500": 1, "200": 7, "302": 2},
+		Errors:      []string{"Internal server error"},
+	}
+
+	got := NewMetrics(Results{
 		&Result{500, time.Unix(0, 0), 100 * time.Millisecond, 10, 30, "Internal server error"},
 		&Result{200, time.Unix(1, 0), 20 * time.Millisecond, 20, 20, ""},
-		&Result{302, time.Unix(0, 0), 10 * time.Millisecond, 20, 20, ""},
-		&Result{200, time.Unix(2, 0), 30 * time.Millisecond, 30, 10, ""},
+		&Result{302, time.Unix(2, 0), 10 * time.Millisecond, 20, 20, ""},
+		&Result{200, time.Unix(3, 0), 75 * time.Millisecond, 30, 10, ""},
+		&Result{200, time.Unix(4, 0), 200 * time.Millisecond, 20, 20, ""},
+		&Result{200, time.Unix(5, 0), 110 * time.Millisecond, 20, 20, ""},
+		&Result{302, time.Unix(6, 0), 120 * time.Millisecond, 20, 20, ""},
+		&Result{200, time.Unix(7, 0), 130 * time.Millisecond, 30, 10, ""},
+		&Result{200, time.Unix(8, 0), 166 * time.Millisecond, 30, 10, ""},
+		&Result{200, time.Unix(9, 0), 190 * time.Millisecond, 30, 10, ""},
 	})
 
-	for field, values := range map[string][]float64{
-		"Rate":          {m.Rate, 2.0},
-		"BytesIn.Mean":  {m.BytesIn.Mean, 20.0},
-		"BytesOut.Mean": {m.BytesOut.Mean, 20.0},
-		"Sucess":        {m.Success, 0.750000},
-	} {
-		if values[0] != values[1] {
-			t.Errorf("%s: want: %f, got: %f", field, values[1], values[0])
-		}
-	}
-
-	for field, values := range map[string][]time.Duration{
-		"Latencies.Max":  {m.Latencies.Max, 100 * time.Millisecond},
-		"Latencies.Mean": {m.Latencies.Mean, 40 * time.Millisecond},
-		"Latencies.P50":  {m.Latencies.P50, 20 * time.Millisecond},
-		"Latencies.P95":  {m.Latencies.P95, 30 * time.Millisecond},
-		"Latencies.P99":  {m.Latencies.P99, 30 * time.Millisecond},
-		"Duration":       {m.Duration, 2 * time.Second},
-		"Wait":           {m.Wait, 30 * time.Millisecond},
-	} {
-		if values[0] != values[1] {
-			t.Errorf("%s: want: %s, got: %s", field, values[1], values[0])
-		}
-	}
-
-	for field, values := range map[string][]uint64{
-		"BytesOut.Total": {m.BytesOut.Total, 80},
-		"BytesIn.Total":  {m.BytesIn.Total, 80},
-		"Requests":       {m.Requests, 4},
-	} {
-		if values[0] != values[1] {
-			t.Errorf("%s: want: %d, got: %d", field, values[1], values[0])
-		}
-	}
-
-	if len(m.StatusCodes) != 3 || m.StatusCodes["200"] != 2 || m.StatusCodes["500"] != 1 || m.StatusCodes["302"] != 1 {
-		t.Errorf("StatusCodes: want: %v, got: %v", map[int]int{200: 2, 500: 1}, m.StatusCodes)
-	}
-
-	err := "Internal server error"
-	if len(m.Errors) != 1 || m.Errors[0] != err {
-		t.Errorf("Errors: want: %v, got: %v", []string{err}, m.Errors)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("\ngot:  %+v\nwant: %+v", got, want)
 	}
 }
 


### PR DESCRIPTION
This change implements R's 8th type of quantile estimation which is
approximately median-unbiased regardless of the data distribution.

Fixes #129  /cc @alexeyrodriguez