### PR TITLE
Allow targets with custom bodies to be separated by empty line as stated in documentation

### DIFF
--- a/lib/targets.go
+++ b/lib/targets.go
@@ -157,6 +157,7 @@ func NewLazyTargeter(src io.Reader, body []byte, hdr http.Header) Targeter {
 		if err = sc.Err(); err != nil {
 			return ErrNoTargets
 		}
+		_ = sc.Peek()
 		return nil
 	}
 }

--- a/lib/targets.go
+++ b/lib/targets.go
@@ -138,8 +138,22 @@ func NewLazyTargeter(src io.Reader, body []byte, hdr http.Header) Targeter {
 			if line = strings.TrimSpace(sc.Text()); line == "" {
 				break
 			} else if strings.HasPrefix(line, "@") {
-				if tgt.Body, err = ioutil.ReadFile(line[1:]); err != nil {
-					return fmt.Errorf("bad body: %s", err)
+				if strings.HasPrefix(line, "@<<") {
+					tag := line[3:]
+					buf := bytes.Buffer{}
+					for sc.Scan() {
+						line = sc.Text()
+						if line == tag {
+							break
+						}
+						buf.WriteString(line + "\n")
+					}
+					tgt.Body = buf.Bytes()
+					break
+				} else {
+					if tgt.Body, err = ioutil.ReadFile(line[1:]); err != nil {
+						return fmt.Errorf("bad body: %s", err)
+					}
 				}
 				break
 			}

--- a/lib/targets_test.go
+++ b/lib/targets_test.go
@@ -134,6 +134,11 @@ func TestNewLazyTargeter(t *testing.T) {
 		POST http://foobar.org/fnord
 		Authorization: x12345
 		@`, bodyf.Name(),
+		`
+
+		POST http://foobar.org/fnord/2
+		Authorization: x67890
+		@`, bodyf.Name(),
 	)
 
 	src := bytes.NewBufferString(strings.TrimSpace(targets))
@@ -166,6 +171,15 @@ func TestNewLazyTargeter(t *testing.T) {
 			Body:   []byte("Hello world!"),
 			Header: http.Header{
 				"Authorization": []string{"x12345"},
+				"Content-Type":  []string{"text/plain"},
+			},
+		},
+		{
+			Method: "POST",
+			URL:    "http://foobar.org/fnord/2",
+			Body:   []byte("Hello world!"),
+			Header: http.Header{
+				"Authorization": []string{"x67890"},
 				"Content-Type":  []string{"text/plain"},
 			},
 		},

--- a/lib/targets_test.go
+++ b/lib/targets_test.go
@@ -139,6 +139,15 @@ func TestNewLazyTargeter(t *testing.T) {
 		POST http://foobar.org/fnord/2
 		Authorization: x67890
 		@`, bodyf.Name(),
+		`
+
+POST http://foobar.org/herebody
+@<<BODY
+{
+    "hello": "world"
+}
+BODY
+`,
 	)
 
 	src := bytes.NewBufferString(strings.TrimSpace(targets))
@@ -181,6 +190,14 @@ func TestNewLazyTargeter(t *testing.T) {
 			Header: http.Header{
 				"Authorization": []string{"x67890"},
 				"Content-Type":  []string{"text/plain"},
+			},
+		},
+		{
+			Method: "POST",
+			URL:    "http://foobar.org/herebody",
+			Body:   []byte("{\n    \"hello\": \"world\"\n}\n"),
+			Header: http.Header{
+				"Content-Type": []string{"text/plain"},
 			},
 		},
 	} {


### PR DESCRIPTION
Fixes #138 