### PR TITLE
Allow targets contain inline bodies similar to shell "here tag"

### DIFF
--- a/lib/targets.go
+++ b/lib/targets.go
@@ -106,8 +106,15 @@ func NewLazyTargeter(src io.Reader, body []byte, hdr http.Header) Targeter {
 			return ErrNilTarget
 		}
 
-		if !sc.Scan() {
-			return ErrNoTargets
+		var line string
+		for {
+			if !sc.Scan() {
+				return ErrNoTargets
+			}
+			line = strings.TrimSpace(sc.Text())
+			if len(line) != 0 {
+				break
+			}
 		}
 
 		tgt.Body = body
@@ -115,7 +122,7 @@ func NewLazyTargeter(src io.Reader, body []byte, hdr http.Header) Targeter {
 		for k, vs := range hdr {
 			tgt.Header[k] = vs
 		}
-		line := strings.TrimSpace(sc.Text())
+
 		tokens := strings.SplitN(line, " ", 2)
 		if len(tokens) < 2 {
 			return fmt.Errorf("bad target: %s", line)

--- a/lib/targets_test.go
+++ b/lib/targets_test.go
@@ -140,6 +140,15 @@ func TestNewLazyTargeter(t *testing.T) {
 		POST http://foobar.org/fnord/2
 		Authorization: x67890
 		@`, bodyf.Name(),
+		`
+
+		POST http://foobar.org/herebody
+		@<<BODY
+{
+    "hello": "world"
+}
+BODY
+`,
 	)
 
 	src := bytes.NewBufferString(strings.TrimSpace(targets))
@@ -182,6 +191,14 @@ func TestNewLazyTargeter(t *testing.T) {
 			Header: http.Header{
 				"Authorization": []string{"x67890"},
 				"Content-Type":  []string{"text/plain"},
+			},
+		},
+		{
+			Method: "POST",
+			URL:    "http://foobar.org/herebody",
+			Body:   []byte("{\n    \"hello\": \"world\"\n}\n"),
+			Header: http.Header{
+				"Content-Type": []string{"text/plain"},
 			},
 		},
 	} {

--- a/lib/targets_test.go
+++ b/lib/targets_test.go
@@ -134,6 +134,12 @@ func TestNewLazyTargeter(t *testing.T) {
 		POST http://foobar.org/fnord
 		Authorization: x12345
 		@`, bodyf.Name(),
+		`
+
+
+		POST http://foobar.org/fnord/2
+		Authorization: x67890
+		@`, bodyf.Name(),
 	)
 
 	src := bytes.NewBufferString(strings.TrimSpace(targets))
@@ -166,6 +172,15 @@ func TestNewLazyTargeter(t *testing.T) {
 			Body:   []byte("Hello world!"),
 			Header: http.Header{
 				"Authorization": []string{"x12345"},
+				"Content-Type":  []string{"text/plain"},
+			},
+		},
+		{
+			Method: "POST",
+			URL:    "http://foobar.org/fnord/2",
+			Body:   []byte("Hello world!"),
+			Header: http.Header{
+				"Authorization": []string{"x67890"},
 				"Content-Type":  []string{"text/plain"},
 			},
 		},


### PR DESCRIPTION
It allows targets to have bodies inline (instead of path to a file) as follows:

```
POST http://foo.bar/
Content-Type: application/json; charset=utf-8
@<<BODY
{
    "one": 1,
    "two": 2
}
BODY
```

Where BODY is arbitrary tag.

I understand that the patch does not add cleanliness to the target generator code but if idea and feature is OK I'll clean and refactor it in the next step.
