### PR TITLE
Infinite attack

### DIFF
--- a/attack.go
+++ b/attack.go
@@ -30,7 +30,7 @@ func attackCmd() command {
 	fs.StringVar(&opts.bodyf, "body", "", "Requests body file")
 	fs.StringVar(&opts.certf, "cert", "", "x509 Certificate file")
 	fs.BoolVar(&opts.lazy, "lazy", false, "Read targets lazily")
-	fs.DurationVar(&opts.duration, "duration", 10*time.Second, "Duration of the test")
+	fs.DurationVar(&opts.duration, "duration", 0, "Duration of the test [0 = forever]")
 	fs.DurationVar(&opts.timeout, "timeout", vegeta.DefaultTimeout, "Requests timeout")
 	fs.Uint64Var(&opts.rate, "rate", 50, "Requests per second")
 	fs.Uint64Var(&opts.workers, "workers", vegeta.DefaultWorkers, "Initial number of workers")
@@ -47,9 +47,8 @@ func attackCmd() command {
 }
 
 var (
-	errZeroDuration = errors.New("duration must be bigger than zero")
-	errZeroRate     = errors.New("rate must be bigger than zero")
-	errBadCert      = errors.New("bad certificate")
+	errZeroRate = errors.New("rate must be bigger than zero")
+	errBadCert  = errors.New("bad certificate")
 )
 
 // attackOpts aggregates the attack function command options
@@ -75,10 +74,6 @@ type attackOpts struct {
 func attack(opts *attackOpts) (err error) {
 	if opts.rate == 0 {
 		return errZeroRate
-	}
-
-	if opts.duration == 0 {
-		return errZeroDuration
 	}
 
 	files := map[string]io.Reader{}

--- a/lib/attack.go
+++ b/lib/attack.go
@@ -147,11 +147,11 @@ func TLSConfig(c *tls.Config) func(*Attacker) {
 // runs until Stop is called. Results are put into the returned channel as soon
 // as they arrive.
 func (a *Attacker) Attack(tr Targeter, rate uint64, du time.Duration) <-chan *Result {
-	workers := &sync.WaitGroup{}
+	var workers sync.WaitGroup
 	results := make(chan *Result)
 	ticks := make(chan time.Time)
 	for i := uint64(0); i < a.workers; i++ {
-		go a.attack(tr, workers, ticks, results)
+		go a.attack(tr, &workers, ticks, results)
 	}
 
 	go func() {
@@ -172,7 +172,7 @@ func (a *Attacker) Attack(tr Targeter, rate uint64, du time.Duration) <-chan *Re
 			case <-a.stopch:
 				return
 			default: // all workers are blocked. start one more and try again
-				go a.attack(tr, workers, ticks, results)
+				go a.attack(tr, &workers, ticks, results)
 			}
 		}
 	}()

--- a/lib/attack_test.go
+++ b/lib/attack_test.go
@@ -25,7 +25,28 @@ func TestAttackRate(t *testing.T) {
 		hits++
 	}
 	if got, want := hits, rate; got != want {
-		t.Fatalf("got: %v, want: %v", rate, hits)
+		t.Fatalf("got: %v, want: %v", got, want)
+	}
+}
+
+func TestAttackDuration(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}),
+	)
+	tr := NewStaticTargeter(Target{Method: "GET", URL: server.URL})
+	atk := NewAttacker()
+	time.AfterFunc(2*time.Second, func() { t.Fatal("Timed out") })
+
+	rate, hits := uint64(100), uint64(0)
+	for range atk.Attack(tr, rate, 0) {
+		if hits++; hits == 100 {
+			atk.Stop()
+			break
+		}
+	}
+
+	if got, want := hits, rate; got != want {
+		t.Fatalf("got: %v, want: %v", got, want)
 	}
 }
 


### PR DESCRIPTION
This PR enables vegeta to run for indeterminate time until no more targets can be read or when explicitly stopped.

Fixes #149 