### PR TITLE
README: simplify Installing -> Source commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ $ brew update && brew install vegeta
 You need `go` installed and `GOBIN` in your `PATH`. Once that is done, run the
 command:
 ```shell
-$ go get github.com/tsenart/vegeta
-$ go install github.com/tsenart/vegeta
+$ go get -u github.com/tsenart/vegeta
 ```
 
 ## Contributing


### PR DESCRIPTION
- `go install github.com/tsenart/vegeta` is not needed because `go get` already performs an install.
- Add `-u` flag to `go get` to ensure that the latest version is installed.