### PR TITLE
issue-173

### DIFF
--- a/lib/attack.go
+++ b/lib/attack.go
@@ -243,8 +243,9 @@ func (a *Attacker) hit(tr Targeter, tm time.Time) *Result {
 		// ignore redirect errors when the user set --redirects=NoFollow
 		if a.redirects == NoFollow && strings.Contains(err.Error(), "stopped after") {
 			err = nil
-		}
-		return &res
+		} else {
+			return &res
+        	}
 	}
 	defer r.Body.Close()
 


### PR DESCRIPTION
thanks to this change successful requests with redirects parameters set to -1 will be reported correctly in the result file (with 302 status instead of 0)