### PR TITLE
#206: support 'baseUri' switch for target URL

### DIFF
--- a/attack.go
+++ b/attack.go
@@ -32,6 +32,7 @@ func attackCmd() command {
 	fs.BoolVar(&opts.http2, "http2", true, "Send HTTP/2 requests when supported by the server")
 	fs.BoolVar(&opts.insecure, "insecure", false, "Ignore invalid server TLS certificates")
 	fs.BoolVar(&opts.lazy, "lazy", false, "Read targets lazily")
+	fs.StringVar(&opts.baseURI, "baseUri", "", "Base URI for the target URL")
 	fs.DurationVar(&opts.duration, "duration", 0, "Duration of the test [0 = forever]")
 	fs.DurationVar(&opts.timeout, "timeout", vegeta.DefaultTimeout, "Requests timeout")
 	fs.Uint64Var(&opts.rate, "rate", 50, "Requests per second")
@@ -64,6 +65,7 @@ type attackOpts struct {
 	http2       bool
 	insecure    bool
 	lazy        bool
+	baseURI     string
 	duration    time.Duration
 	timeout     time.Duration
 	rate        uint64
@@ -108,8 +110,8 @@ func attack(opts *attackOpts) (err error) {
 		hdr = opts.headers.Header
 	)
 	if opts.lazy {
-		tr = vegeta.NewLazyTargeter(src, body, hdr)
-	} else if tr, err = vegeta.NewEagerTargeter(src, body, hdr); err != nil {
+		tr = vegeta.NewLazyTargeter(src, body, hdr, opts.baseURI)
+	} else if tr, err = vegeta.NewEagerTargeter(src, body, hdr, opts.baseURI); err != nil {
 		return err
 	}
 

--- a/lib/targets_test.go
+++ b/lib/targets_test.go
@@ -62,7 +62,7 @@ func TestNewEagerTargeter(t *testing.T) {
 	t.Parallel()
 
 	src := []byte("GET http://:6060/\nHEAD http://:6606/")
-	read, err := NewEagerTargeter(bytes.NewReader(src), []byte("body"), nil)
+	read, err := NewEagerTargeter(bytes.NewReader(src), []byte("body"), nil, "")
 	if err != nil {
 		t.Fatalf("Couldn't parse valid source: %s", err)
 	}
@@ -110,7 +110,7 @@ func TestNewLazyTargeter(t *testing.T) {
 			: 1234`,
 	} {
 		src := bytes.NewBufferString(strings.TrimSpace(def))
-		read := NewLazyTargeter(src, []byte{}, http.Header{})
+		read := NewLazyTargeter(src, []byte{}, http.Header{}, "")
 		if got := read(&Target{}); got == nil || !strings.HasPrefix(got.Error(), want.Error()) {
 			t.Errorf("got: %s, want: %s\n%s", got, want, def)
 		}
@@ -145,7 +145,7 @@ func TestNewLazyTargeter(t *testing.T) {
 	)
 
 	src := bytes.NewBufferString(strings.TrimSpace(targets))
-	read := NewLazyTargeter(src, []byte{}, http.Header{"Content-Type": []string{"text/plain"}})
+	read := NewLazyTargeter(src, []byte{}, http.Header{"Content-Type": []string{"text/plain"}}, "")
 	for _, want := range []Target{
 		{
 			Method: "GET",
@@ -205,13 +205,13 @@ func TestNewLazyTargeter(t *testing.T) {
 func TestErrNilTarget(t *testing.T) {
 	t.Parallel()
 
-	eager, err := NewEagerTargeter(strings.NewReader("GET http://foo.bar"), nil, nil)
+	eager, err := NewEagerTargeter(strings.NewReader("GET http://foo.bar"), nil, nil, "")
 	if err != nil {
 		t.Fatal(err)
 	}
 	for i, tr := range []Targeter{
 		NewStaticTargeter(Target{Method: "GET", URL: "http://foo.bar"}),
-		NewLazyTargeter(strings.NewReader("GET http://foo.bar"), nil, nil),
+		NewLazyTargeter(strings.NewReader("GET http://foo.bar"), nil, nil, ""),
 		eager,
 	} {
 		if got, want := tr(nil), ErrNilTarget; got != want {


### PR DESCRIPTION
for #206 

added a new switch `-baseUri` so that it will be pre-appended to the target url if it's relative path, so that we can reuse the target file and switch to different env on command line.

```bash
echo "GET /health-check" | vegeta attack -timeout=60s -duration=10s -baseUri=http://localhost:8080 | tee results.bin | vegeta report
```
equals to:
```bash
echo "GET http://localhost:8080/health-check" | vegeta attack -timeout=60s -duration=10s | tee results.bin | vegeta report
```