### PR TITLE
PTAL allow any upper-case ASCII word to be an http method

### DIFF
--- a/lib/targets.go
+++ b/lib/targets.go
@@ -127,12 +127,10 @@ func NewLazyTargeter(src io.Reader, body []byte, hdr http.Header) Targeter {
 		if len(tokens) < 2 {
 			return fmt.Errorf("bad target: %s", line)
 		}
-		switch tokens[0] {
-		case "HEAD", "GET", "PUT", "POST", "PATCH", "OPTIONS", "DELETE":
-			tgt.Method = tokens[0]
-		default:
+		if !isHttpMethod(tokens[0]) {
 			return fmt.Errorf("bad method: %s", tokens[0])
 		}
+		tgt.Method = tokens[0]
 		if _, err = url.ParseRequestURI(tokens[1]); err != nil {
 			return fmt.Errorf("bad URL: %s", tokens[1])
 		}
@@ -171,10 +169,16 @@ func NewLazyTargeter(src io.Reader, body []byte, hdr http.Header) Targeter {
 	}
 }
 
-var httpMethodChecker = regexp.MustCompile("^(HEAD|GET|PUT|POST|PATCH|OPTIONS|DELETE) ")
+var httpMethodChecker = regexp.MustCompile("^[A-Z]*$")
 
-func startsWithHTTPMethod(t string) bool {
+func isHttpMethod(t string) bool {
 	return httpMethodChecker.MatchString(t)
+}
+
+// a line starts with an http method when the first word is uppercase ascii followed by an url
+func startsWithHTTPMethod(t string) bool {
+	parts := strings.Split(t, " ")
+	return len(parts) == 2 && isHttpMethod(parts[0])
 }
 
 // Wrap a Scanner so we can cheat and look at the next value and react accordingly,

--- a/lib/targets.go
+++ b/lib/targets.go
@@ -127,7 +127,7 @@ func NewLazyTargeter(src io.Reader, body []byte, hdr http.Header) Targeter {
 		if len(tokens) < 2 {
 			return fmt.Errorf("bad target: %s", line)
 		}
-		if !isHttpMethod(tokens[0]) {
+		if !startsWithHTTPMethod(line) {
 			return fmt.Errorf("bad method: %s", tokens[0])
 		}
 		tgt.Method = tokens[0]
@@ -169,16 +169,11 @@ func NewLazyTargeter(src io.Reader, body []byte, hdr http.Header) Targeter {
 	}
 }
 
-var httpMethodChecker = regexp.MustCompile("^[A-Z]*$")
-
-func isHttpMethod(t string) bool {
-	return httpMethodChecker.MatchString(t)
-}
+var httpMethodChecker = regexp.MustCompile("^[A-Z]+\\s")
 
 // a line starts with an http method when the first word is uppercase ascii followed by an url
 func startsWithHTTPMethod(t string) bool {
-	parts := strings.Split(t, " ")
-	return len(parts) == 2 && isHttpMethod(parts[0])
+	return httpMethodChecker.MatchString(t)
 }
 
 // Wrap a Scanner so we can cheat and look at the next value and react accordingly,

--- a/lib/targets.go
+++ b/lib/targets.go
@@ -171,7 +171,8 @@ func NewLazyTargeter(src io.Reader, body []byte, hdr http.Header) Targeter {
 
 var httpMethodChecker = regexp.MustCompile("^[A-Z]+\\s")
 
-// a line starts with an http method when the first word is uppercase ascii followed by an url
+// A line starts with an http method when the first word is uppercase ascii
+// followed by a space.
 func startsWithHTTPMethod(t string) bool {
 	return httpMethodChecker.MatchString(t)
 }

--- a/lib/targets_test.go
+++ b/lib/targets_test.go
@@ -93,8 +93,9 @@ func TestNewLazyTargeter(t *testing.T) {
 	t.Parallel()
 
 	for want, def := range map[error]string{
+		errors.New("bad method"): "DO_WORK http://:6000",
+		errors.New("bad method"): "DOwork http://:6000",
 		errors.New("bad target"): "GET",
-		errors.New("bad method"): "SET http://:6060",
 		errors.New("bad URL"):    "GET foobar",
 		errors.New("bad body"): `
 			GET http://:6060
@@ -142,6 +143,9 @@ func TestNewLazyTargeter(t *testing.T) {
 		POST http://foobar.org/fnord/2
 		Authorization: x67890
 		@`, bodyf.Name(),
+		`
+
+		SUBSCRIBE http://foobar.org/sub`,
 	)
 
 	src := bytes.NewBufferString(strings.TrimSpace(targets))
@@ -185,6 +189,12 @@ func TestNewLazyTargeter(t *testing.T) {
 				"Authorization": []string{"x67890"},
 				"Content-Type":  []string{"text/plain"},
 			},
+		},
+		{
+			Method: "SUBSCRIBE",
+			URL:    "http://foobar.org/sub",
+ 			Body:   []byte{},
+ 			Header: http.Header{"Content-Type": []string{"text/plain"}},
 		},
 	} {
 		var got Target


### PR DESCRIPTION
The motivation and context for this PR are detailed in the proposal issue: https://github.com/tsenart/vegeta/issues/214

The implementation has changes as per maintainer's suggestions:
- with this PR vegeta now supports any upper-case ASCII word as a valid HTTP verb, not just  POST/GET/PUT/PATCH/DETELE/HEAD/OPTIONS...

CC @tsenart 