### PR TITLE
mark responses as success in no redirect following mode.

### DIFF
--- a/lib/attack.go
+++ b/lib/attack.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -95,10 +94,14 @@ func Redirects(n int) func(*Attacker) {
 	return func(a *Attacker) {
 		a.redirects = n
 		a.client.CheckRedirect = func(_ *http.Request, via []*http.Request) error {
-			if len(via) > n {
+			switch {
+			case n == NoFollow:
+				return http.ErrUseLastResponse
+			case n < len(via):
 				return fmt.Errorf("stopped after %d redirects", n)
+			default:
+				return nil
 			}
-			return nil
 		}
 	}
 }
@@ -241,10 +244,6 @@ func (a *Attacker) hit(tr Targeter, tm time.Time) *Result {
 
 	r, err := a.client.Do(req)
 	if err != nil {
-		// ignore redirect errors when the user set --redirects=NoFollow
-		if a.redirects == NoFollow && strings.Contains(err.Error(), "stopped after") {
-			err = nil
-		}
 		return &res
 	}
 	defer r.Body.Close()

--- a/lib/attack_test.go
+++ b/lib/attack_test.go
@@ -91,8 +91,12 @@ func TestNoFollow(t *testing.T) {
 	defer server.Close()
 	atk := NewAttacker(Redirects(NoFollow))
 	tr := NewStaticTargeter(Target{Method: "GET", URL: server.URL})
-	if res := atk.hit(tr, time.Now()); res.Error != "" {
+	res := atk.hit(tr, time.Now())
+	if res.Error != "" {
 		t.Fatalf("got err: %v", res.Error)
+	}
+	if res.Code != 302 {
+		t.Fatalf("res.Code => %d, want %d", res.Code, 302)
 	}
 }
 


### PR DESCRIPTION
## Issue which this PR solves

Vegeta does not mark responses as success when `-1` is set to the attack `-redirects` option. `Bytes In`, `Bytes Out`, `Success` and `Status Codes` of a report are zeros as below:

```shell
echo "GET http://xxxx.xxxx" | vegeta attack -redirects -1 -rate 1 -duration 10s | tee results.bin | vegeta report
Requests      [total, rate]            10, 1.11
Duration      [total, attack, wait]    9.003078071s, 8.999999898s, 3.078173ms
Latencies     [mean, 50, 95, 99, max]  12.427662ms, 3.246776ms, 3.823605ms, 3.823605ms, 96.816248ms
Bytes In      [total, mean]            0, 0.00
Bytes Out     [total, mean]            0, 0.00
Success       [ratio]                  0.00%
Status Codes  [code:count]             0:10
Error Set:
```

## Changes in this PR

Have `a.client.CheckRedirect` return `http.ErrUseLastResponse` when `-1` is set to the attack `-redirects` option. By doing this, Go's HTTP client does not follow redirects and returns the first HTTP response with its body unclosed. See https://golang.org/src/net/http/client.go?h=ErrUseLastResponse#L398 for the details.