### PR TITLE
Add option to override HTTP Proxy on Attacker.

### DIFF
--- a/lib/attack.go
+++ b/lib/attack.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -103,6 +104,15 @@ func Redirects(n int) func(*Attacker) {
 				return nil
 			}
 		}
+	}
+}
+
+// Proxy returns a functional option which sets the `Proxy` field on
+// the http.Client's Transport
+func Proxy(proxy func(*http.Request) (*url.URL, error)) func(*Attacker) {
+	return func(a *Attacker) {
+		tr := a.client.Transport.(*http.Transport)
+		tr.Proxy = proxy
 	}
 }
 


### PR DESCRIPTION
Currently an `Attacker` sets the `Proxy` field to `http.ProxyFromEnvironment` which uses a proxy if the environment variables are present. This means there is no way to use a proxy only for a _specific_ attacker -- it's global. 

This change adds the ability to override the proxy settings on an `Attacker` instance.