### PR TITLE
Add 90th percentile to the results

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -53,6 +53,10 @@
   branch = "master"
   name = "golang.org/x/net"
 
+[[constraint]]
+  branch = "master"
+  name = "github.com/daluu/golibs/time"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/README.md
+++ b/README.md
@@ -281,13 +281,13 @@ Specifies the kind of report to be generated. It defaults to text.
 
 ##### `text`
 ```console
-Requests      [total, rate]             1200, 120.00
-Duration      [total, attack, wait]     10.094965987s, 9.949883921s, 145.082066ms
-Latencies     [mean, 50, 95, 99, max]   113.172398ms, 108.272568ms, 140.18235ms, 247.771566ms, 264.815246ms
-Bytes In      [total, mean]             3714690, 3095.57
-Bytes Out     [total, mean]             0, 0.00
-Success       [ratio]                   55.42%
-Status Codes  [code:count]              0:535  200:665
+Requests      [total, rate]                1200, 120.10
+Duration      [total, attack, wait]        9.992530625s, 9.991666185s, 864.44µs
+Latencies     [mean, 50, 90, 95, 99, max]  1.623143ms, 1.420976ms, 2.808559ms, 2.941666ms, 3.120381ms, 4.092141ms
+Bytes In      [total, mean]                394800, 329.00
+Bytes Out     [total, mean]                0, 0.00
+Success       [ratio]                      55.42%
+Status Codes  [code:count]                 0:535  200:665
 Error Set:
 Get http://localhost:6060: dial tcp 127.0.0.1:6060: connection refused
 Get http://localhost:6060: read tcp 127.0.0.1:6060: connection reset by peer
@@ -301,33 +301,34 @@ Get http://localhost:6060: http: can't write HTTP request on broken connection
 ```json
 {
   "latencies": {
-    "total": 237119463,
-    "mean": 2371194,
-    "50th": 2854306,
-    "95th": 3478629,
-    "99th": 3530000,
-    "max": 3660505
+    "total": 1947772197,
+    "mean": 1623143,
+    "50th": 1420976,
+    "90th": 2808559,
+    "95th": 2941666,
+    "99th": 3120381,
+    "max": 4092141
   },
   "bytes_in": {
-    "total": 606700,
-    "mean": 6067
+    "total": 394800,
+    "mean": 329
   },
   "bytes_out": {
     "total": 0,
     "mean": 0
   },
-  "earliest": "2015-09-19T14:45:50.645818631+02:00",
-  "latest": "2015-09-19T14:45:51.635818575+02:00",
-  "end": "2015-09-19T14:45:51.639325797+02:00",
-  "duration": 989999944,
-  "wait": 3507222,
-  "requests": 100,
-  "rate": 101.01010672380401,
+  "earliest": "2018-06-25T23:24:22.823753167-07:00",
+  "latest": "2018-06-25T23:24:32.815419352-07:00",
+  "end": "2018-06-25T23:24:32.816283792-07:00",
+  "duration": 9991666185,
+  "wait": 864440,
+  "requests": 1200,
+  "rate": 120.10008919248136,
   "success": 1,
   "status_codes": {
-    "200": 100
+    "200": 1200
   },
-  "errors": []
+  "errors": null
 }
 ```
 ##### `plot`
@@ -406,12 +407,12 @@ It'll read and sort them by timestamp before generating reports.
 
 ```console
 $ vegeta report -inputs="10.0.1.1.bin,10.0.2.1.bin,10.0.3.1.bin"
-Requests      [total, rate]         3600000, 60000.00
-Latencies     [mean, 95, 99, max]   223.340085ms, 326.913687ms, 416.537743ms, 7.788103259s
-Bytes In      [total, mean]         3714690, 3095.57
-Bytes Out     [total, mean]         0, 0.00
-Success       [ratio]               100.0%
-Status Codes  [code:count]          200:3600000
+Requests      [total, rate]             3600000, 60000.00
+Latencies     [mean, 90, 95, 99, max]   223.340085ms, 318.808559ms, 326.913687ms, 416.537743ms, 7.788103259s
+Bytes In      [total, mean]             3714690, 3095.57
+Bytes Out     [total, mean]             0, 0.00
+Success       [ratio]                   100.0%
+Status Codes  [code:count]              200:3600000
 Error Set:
 ```
 

--- a/lib/metrics.go
+++ b/lib/metrics.go
@@ -119,7 +119,7 @@ type LatencyMetrics struct {
 	Mean time.Duration `json:"mean"`
 	// P50 is the 50th percentile request latency.
 	P50 time.Duration `json:"50th"`
-	// P90 is the 95th percentile request latency.
+	// P90 is the 90th percentile request latency.
 	P90 time.Duration `json:"90th"`
 	// P95 is the 95th percentile request latency.
 	P95 time.Duration `json:"95th"`

--- a/lib/metrics.go
+++ b/lib/metrics.go
@@ -92,6 +92,7 @@ func (m *Metrics) Close() {
 	m.Success = float64(m.success) / float64(m.Requests)
 	m.Latencies.Mean = time.Duration(float64(m.Latencies.Total) / float64(m.Requests))
 	m.Latencies.P50 = m.Latencies.Quantile(0.50)
+	m.Latencies.P90 = m.Latencies.Quantile(0.90)
 	m.Latencies.P95 = m.Latencies.Quantile(0.95)
 	m.Latencies.P99 = m.Latencies.Quantile(0.99)
 }
@@ -118,6 +119,8 @@ type LatencyMetrics struct {
 	Mean time.Duration `json:"mean"`
 	// P50 is the 50th percentile request latency.
 	P50 time.Duration `json:"50th"`
+	// P90 is the 95th percentile request latency.
+	P90 time.Duration `json:"90th"`
 	// P95 is the 95th percentile request latency.
 	P95 time.Duration `json:"95th"`
 	// P99 is the 99th percentile request latency.

--- a/lib/metrics_test.go
+++ b/lib/metrics_test.go
@@ -43,7 +43,7 @@ func TestMetrics_Add(t *testing.T) {
 			Total:     duration("50.005s"),
 			Mean:      duration("5.0005ms"),
 			P50:       duration("5.0005ms"),
-			P90:       duration("8.995ms"),
+			P90:       duration("9.0005ms"),
 			P95:       duration("9.5005ms"),
 			P99:       duration("9.9005ms"),
 			Max:       duration("10ms"),
@@ -114,11 +114,13 @@ func BenchmarkMetrics(b *testing.B) {
 	}{
 		{"streadway/quantile", streadway.New(
 			streadway.Known(0.50, 0.01),
-			streadway.Known(0.95, 0.001),
-			streadway.Known(0.99, 0.0005),
+			streadway.Known(0.90, 0.001),
+			streadway.Known(0.95, 0.005),
+			streadway.Known(0.99, 0.0001),
 		)},
 		{"bmizerany/perks/quantile", newBmizeranyEstimator(
 			0.50,
+			0.90,
 			0.95,
 			0.99,
 		)},

--- a/lib/metrics_test.go
+++ b/lib/metrics_test.go
@@ -43,6 +43,7 @@ func TestMetrics_Add(t *testing.T) {
 			Total:     duration("50.005s"),
 			Mean:      duration("5.0005ms"),
 			P50:       duration("5.0005ms"),
+			P90:       duration("8.995ms"),
 			P95:       duration("9.5005ms"),
 			P99:       duration("9.9005ms"),
 			Max:       duration("10ms"),

--- a/lib/reporters.go
+++ b/lib/reporters.go
@@ -58,7 +58,7 @@ func NewHistogramReporter(h *Histogram) Reporter {
 func NewTextReporter(m *Metrics) Reporter {
 	const fmtstr = "Requests\t[total, rate]\t%d, %.2f\n" +
 		"Duration\t[total, attack, wait]\t%s, %s, %s\n" +
-		"Latencies\t[mean, 50, 95, 99, max]\t%s, %s, %s, %s, %s\n" +
+		"Latencies\t[mean, 50, 90, 95, 99, max]\t%s, %s, %s, %s, %s, %s\n" +
 		"Bytes In\t[total, mean]\t%d, %.2f\n" +
 		"Bytes Out\t[total, mean]\t%d, %.2f\n" +
 		"Success\t[ratio]\t%.2f%%\n" +
@@ -69,7 +69,7 @@ func NewTextReporter(m *Metrics) Reporter {
 		if _, err = fmt.Fprintf(tw, fmtstr,
 			m.Requests, m.Rate,
 			m.Duration+m.Wait, m.Duration, m.Wait,
-			m.Latencies.Mean, m.Latencies.P50, m.Latencies.P95, m.Latencies.P99, m.Latencies.Max,
+			m.Latencies.Mean, m.Latencies.P50, m.Latencies.P90, m.Latencies.P95, m.Latencies.P99, m.Latencies.Max,
 			m.BytesIn.Total, m.BytesIn.Mean,
 			m.BytesOut.Total, m.BytesOut.Mean,
 			m.Success*100,

--- a/lib/reporters.go
+++ b/lib/reporters.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	timeutils "github.com/daluu/golibs/time"
 	"github.com/lucasb-eyer/go-colorful"
 )
 
@@ -69,7 +70,7 @@ func NewTextReporter(m *Metrics) Reporter {
 		if _, err = fmt.Fprintf(tw, fmtstr,
 			m.Requests, m.Rate,
 			m.Duration+m.Wait, m.Duration, m.Wait,
-			m.Latencies.Mean, m.Latencies.P50, m.Latencies.P90, m.Latencies.P95, m.Latencies.P99, m.Latencies.Max,
+			timeutils.FormatDuration(m.Latencies.Mean, 3), timeutils.FormatDuration(m.Latencies.P50, 3), timeutils.FormatDuration(m.Latencies.P90, 3), timeutils.FormatDuration(m.Latencies.P95, 3), timeutils.FormatDuration(m.Latencies.P99, 3), timeutils.FormatDuration(m.Latencies.Max, 3),
 			m.BytesIn.Total, m.BytesIn.Mean,
 			m.BytesOut.Total, m.BytesOut.Mean,
 			m.Success*100,


### PR DESCRIPTION
Quite a few tools offer 90th percentile statistic, and that's one metric we do monitor. e.g. jmeter, wrk2, etc. I don't see why vegeta shouldn't include it. Right now 95th % is the closest thing to it, but still that's a higher number.

I assume I got it reasonable but please review the quantile ratios setup and the expected latencies for each quantile with this addition. Which leads to the below question:

And on a related note, any reason to use the specific quantiles package instead of writing code from scratch or using another statistical/percentile/quantile library? I came across these in a quick search, not sure how they compare against the current library used.

https://github.com/montanaflynn/stats/blob/master/percentile.go
https://github.com/bmizerany/perks/tree/master/quantile

I'm not a statistician, so can't say much on this but the current quantile library used at least is a bit confusing to the novice user since we are free to define the ratio's for each percentile - one could make mistakes. Contrast that with percentile libraries for python, node.js/javascript, etc. and it's more straightforward: import library and call a percentile method against an array of values, specifying the desired percentile, no mucking with some percentile/quantile ratio value that maps it to the percentile accuracy.
