### PR TITLE
Prevent null values from being reported in json

### DIFF
--- a/lib/metrics.go
+++ b/lib/metrics.go
@@ -144,4 +144,8 @@ func (m *Metrics) init() {
 			quantile.Known(0.99, 0.0005),
 		)
 	}
+
+	if m.Errors == nil {
+		m.Errors = make([]string, 0)
+	}
 }


### PR DESCRIPTION
Not really familiar with Go or the best way to go about this, however, when using the JSON reporter I noticed that the `errors` set was coming back as null and not an empty set for attacks that had no errors. This looks like it does fix it from a simple comparison of runs before and after the change as well as no regression when there are errors.

Not sure if this is really necessary but this caused some issues for some hacky spinnaker pipelines we have going (that don't like null JSON values apparently) and figured I'd offer this "fix" upstream.