### PR TITLE
Add support for custom DialContext on http.Transport

### DIFF
--- a/lib/attack.go
+++ b/lib/attack.go
@@ -1,6 +1,7 @@
 package vegeta
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -137,6 +138,18 @@ func KeepAlive(keepalive bool) func(*Attacker) {
 			a.dialer.KeepAlive = 0
 			tr.Dial = a.dialer.Dial
 		}
+	}
+}
+
+// DialContext returns a function to set a custom DialContext on the http
+// client's Transport. This is useful for use cases like sending HTTP requests
+// to a unix socket.
+// NOTE: this is not compatible with LocalAddr(), KeepAlive(), Timeout(), or
+// any function that touches the dialer.
+func DialContext(dialContext func(ctx context.Context, network, addr string) (net.Conn, error)) func(*Attacker) {
+	return func(a *Attacker) {
+		tr := a.client.Transport.(*http.Transport)
+		tr.DialContext = dialContext
 	}
 }
 


### PR DESCRIPTION
This supports uses cases such as load testing a unix socket.

The implementation is a bit odd because there are attacker options for
tweaking settings on the standard *net.Dialer, however setting a custom
DialContext means those settings will be ignored. Conversely, setting
*net.Dialer options will cause the custom DialContext to be overwritten.