### PR TITLE
JSON targets format

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,6 +3,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/alecthomas/jsonschema"
+  packages = ["."]
+  revision = "f2c93856175a7dd6abe88c5c3900b67ad054adcc"
+
+[[projects]]
+  branch = "master"
   name = "github.com/lucasb-eyer/go-colorful"
   packages = ["."]
   revision = "8abd3beca3a7f5039809449d6013a0254ac22bb1"
@@ -48,6 +54,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c4733e995a7d5a7521b2b14b7b4a275f0ff10f65871f452e21c3cd1f0bd8a948"
+  inputs-digest = "b7241bb8cec207e1b751be687240fd7f6af51a3a9e37a70c4d62c33a96c1391e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,16 @@ COMMIT=$(shell git rev-parse HEAD)
 VERSION=$(shell git describe --tags --exact-match --always)
 DATE=$(shell date +'%FT%TZ%z')
 
-vegeta: vendor
+vegeta: vendor generate
 	CGO_ENABLED=0 go build -v -a -tags=netgo \
   	-ldflags '-s -w -extldflags "-static" -X main.Version=$(VERSION) -X main.Commit=$(COMMIT) -X main.Date=$(DATE)'
 
 clean-vegeta:
 	rm vegeta
+
+generate: vendor
+	go install ./internal/cmd/...
+	go generate ./...
 
 vendor:
 	dep ensure -v

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ attack command:
       Max open idle connections per target host (default 10000)
   -duration duration
       Duration of the test [0 = forever]
+  -format string
+      Targets format [legacy] (default "legacy")
+  -h2c
+      Send HTTP/2 requests without TLS encryption
   -header value
       Request header
   -http2
@@ -113,47 +117,7 @@ Specifies which profiler to enable during execution. Both *cpu* and
 #### `-version`
 Prints the version and exits.
 
-### `attack`
-```console
-$ vegeta attack -h
-Usage of vegeta attack:
-  -body string
-      Requests body file
-  -cert string
-      TLS client PEM encoded certificate file
-  -connections int
-      Max open idle connections per target host (default 10000)
-  -duration duration
-      Duration of the test [0 = forever]
-  -header value
-      Request header
-  -http2
-      Send HTTP/2 requests when supported by the server (default true)
-  -insecure
-      Ignore invalid server TLS certificates
-  -keepalive
-      Use persistent connections (default true)
-  -key string
-      TLS client PEM encoded private key file
-  -laddr value
-      Local IP address (default 0.0.0.0)
-  -lazy
-      Read targets lazily
-  -output string
-      Output file (default "stdout")
-  -rate uint
-      Requests per second (default 50)
-  -redirects int
-      Number of redirects to follow. -1 will not follow but marks as success (default 10)
-  -root-certs value
-      TLS root certificate files (comma separated list)
-  -targets string
-      Targets file (default "stdin")
-  -timeout duration
-      Requests timeout (default 30s)
-  -workers uint
-      Initial number of workers (default 10)
-```
+### `attack` command
 
 #### `-body`
 Specifies the file whose content will be set as the body of every
@@ -171,6 +135,56 @@ Specifies the amount of time to issue request to the targets.
 The internal concurrency structure's setup has this value as a variable.
 The actual run time of the test can be longer than specified due to the
 responses delay. Use 0 for an infinite attack.
+
+#### `-format`
+Specifies the targets format to decode.
+
+##### `legacy` format
+
+The ill-defined legacy format almost resembles the plain-text HTTP message format but
+doesn't support in-line HTTP bodies, only references to files that are loaded and used
+as request bodies (as exemplified below).
+
+Although targets in this format can be produced by other programs, it was originally
+meant to be used by people writing targets by hand for simple use cases.
+
+Here are a few examples of valid targets files in the legacy format:
+
+Simple targets
+```
+GET http://goku:9090/path/to/dragon?item=ball
+GET http://user:password@goku:9090/path/to
+HEAD http://goku:9090/path/to/success
+```
+
+Targets with custom headers
+```
+GET http://user:password@goku:9090/path/to
+X-Account-ID: 8675309
+
+DELETE http://goku:9090/path/to/remove
+Confirmation-Token: 90215
+Authorization: Token DEADBEEF
+```
+
+Targets with custom bodies
+```
+POST http://goku:9090/things
+@/path/to/newthing.json
+
+PATCH http://goku:9090/thing/71988591
+@/path/to/thing-71988591.json
+```
+
+Targets with custom bodies and headers
+```
+POST http://goku:9090/things
+X-Account-ID: 99
+@/path/to/newthing.json
+```
+
+#### `-h2c`
+Specifies that HTTP2 requests are to be sent over TCP without TLS encryption.
 
 #### `-header`
 Specifies a request header to be used in all targets defined, see `-targets`.
@@ -220,39 +234,6 @@ list. If unspecified, the default system CAs certificates will be used.
 Specifies the attack targets in a line separated file, defaulting to stdin.
 The format should be as follows, combining any or all of the following:
 
-Simple targets
-```
-GET http://goku:9090/path/to/dragon?item=balls
-GET http://user:password@goku:9090/path/to
-HEAD http://goku:9090/path/to/success
-```
-
-Targets with custom headers
-```
-GET http://user:password@goku:9090/path/to
-X-Account-ID: 8675309
-
-DELETE http://goku:9090/path/to/remove
-Confirmation-Token: 90215
-Authorization: Token DEADBEEF
-```
-
-Targets with custom bodies
-```
-POST http://goku:9090/things
-@/path/to/newthing.json
-
-PATCH http://goku:9090/thing/71988591
-@/path/to/thing-71988591.json
-```
-
-Targets with custom bodies and headers
-```
-POST http://goku:9090/things
-X-Account-ID: 99
-@/path/to/newthing.json
-```
-
 #### `-timeout`
 Specifies the timeout for each request. The default is 0 which disables
 timeouts.
@@ -262,17 +243,7 @@ Specifies the initial number of workers used in the attack. The actual
 number of workers will increase if necessary in order to sustain the
 requested rate.
 
-### report
-```console
-$ vegeta report -h
-Usage of vegeta report:
-  -inputs string
-      Input files (comma separated) (default "stdin")
-  -output string
-      Output file (default "stdout")
-  -reporter string
-      Reporter [text, json, plot, hist[buckets]] (default "text")
-```
+### report command
 
 #### `-inputs`
 Specifies the input files to generate the report of, defaulting to stdin.
@@ -363,17 +334,7 @@ Bucket         #     %       Histogram
 [6ms,   +Inf]  4771  25.93%  ###################
 ```
 
-### `dump`
-```console
-$ vegeta dump -h
-Usage of vegeta dump:
-  -dumper string
-      Dumper [json, csv] (default "json")
-  -inputs string
-      Input files (comma separated) (default "stdin")
-  -output string
-      Output file (default "stdout")
-```
+### `dump` command
 
 #### `-inputs`
 Specifies the input files containing attack results to be dumped. You can specify more than one (comma separated).

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ attack command:
   -duration duration
       Duration of the test [0 = forever]
   -format string
-      Targets format [legacy] (default "legacy")
+      Targets format [legacy, json] (default "legacy")
   -h2c
       Send HTTP/2 requests without TLS encryption
   -header value
@@ -138,6 +138,16 @@ responses delay. Use 0 for an infinite attack.
 
 #### `-format`
 Specifies the targets format to decode.
+
+##### `json` format
+
+The JSON format makes integration with programs that produce targets dynamically easier.
+Each target is one JSON object in its own line. If present, the body field must be base64 encoded.
+
+```bash
+jq -ncM '{method: "GET", url: "http://goku", body: "Punch!" | @base64, header: {"Content-Type": ["text/plain"]}}' |
+  vegeta attack -format=json -rate=100 | vegeta dump
+```
 
 ##### `legacy` format
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ Specifies the targets format to decode.
 ##### `json` format
 
 The JSON format makes integration with programs that produce targets dynamically easier.
-Each target is one JSON object in its own line. If present, the body field must be base64 encoded.
+Each target is one JSON object in its own line. The method and url fields are required.
+If present, the body field must be base64 encoded. The generated [JSON Schema](lib/target.schema.json)
+defines the format in detail.
 
 ```bash
 jq -ncM '{method: "GET", url: "http://goku", body: "Punch!" | @base64, header: {"Content-Type": ["text/plain"]}}' |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ attack command:
   -duration duration
       Duration of the test [0 = forever]
   -format string
-      Targets format [legacy, json] (default "legacy")
+      Targets format [http, json] (default "http")
   -h2c
       Send HTTP/2 requests without TLS encryption
   -header value
@@ -149,25 +149,26 @@ jq -ncM '{method: "GET", url: "http://goku", body: "Punch!" | @base64, header: {
   vegeta attack -format=json -rate=100 | vegeta dump
 ```
 
-##### `legacy` format
+##### `http` format
 
-The ill-defined legacy format almost resembles the plain-text HTTP message format but
+The http format almost resembles the plain-text HTTP message format defined in
+[RFC 2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html) but it
 doesn't support in-line HTTP bodies, only references to files that are loaded and used
 as request bodies (as exemplified below).
 
 Although targets in this format can be produced by other programs, it was originally
 meant to be used by people writing targets by hand for simple use cases.
 
-Here are a few examples of valid targets files in the legacy format:
+Here are a few examples of valid targets files in the http format:
 
-Simple targets
+###### Simple targets
 ```
 GET http://goku:9090/path/to/dragon?item=ball
 GET http://user:password@goku:9090/path/to
 HEAD http://goku:9090/path/to/success
 ```
 
-Targets with custom headers
+###### Targets with custom headers
 ```
 GET http://user:password@goku:9090/path/to
 X-Account-ID: 8675309
@@ -177,7 +178,7 @@ Confirmation-Token: 90215
 Authorization: Token DEADBEEF
 ```
 
-Targets with custom bodies
+###### Targets with custom bodies
 ```
 POST http://goku:9090/things
 @/path/to/newthing.json
@@ -186,7 +187,7 @@ PATCH http://goku:9090/thing/71988591
 @/path/to/thing-71988591.json
 ```
 
-Targets with custom bodies and headers
+###### Targets with custom bodies and headers
 ```
 POST http://goku:9090/things
 X-Account-ID: 99

--- a/attack.go
+++ b/attack.go
@@ -118,9 +118,10 @@ func attack(opts *attackOpts) (err error) {
 	case "json":
 		tr = vegeta.NewJSONTargeter(src, body, hdr)
 	case "http":
-		fallthrough
-	default:
 		tr = vegeta.NewHTTPTargeter(src, body, hdr)
+	default:
+		valid := [...]string{vegeta.HTTPTargetFormat, vegeta.JSONTargetFormat}
+		return fmt.Errorf("format %q isn't one of %v", opts.format, valid)
 	}
 
 	if !opts.lazy {

--- a/attack.go
+++ b/attack.go
@@ -127,9 +127,11 @@ func attack(opts *attackOpts) (err error) {
 	}
 
 	if !opts.lazy {
-		if tr, err = vegeta.NewEagerTargeter(tr); err != nil {
+		targets, err := vegeta.ReadAllTargets(tr)
+		if err != nil {
 			return err
 		}
+		tr = vegeta.NewStaticTargeter(targets...)
 	}
 
 	out, err := file(opts.outputf, true)

--- a/attack.go
+++ b/attack.go
@@ -25,7 +25,7 @@ func attackCmd() command {
 
 	fs.StringVar(&opts.name, "name", "", "Attack name")
 	fs.StringVar(&opts.targetsf, "targets", "stdin", "Targets file")
-	fs.StringVar(&opts.format, "format", "legacy", "Targets format [legacy]")
+	fs.StringVar(&opts.format, "format", "legacy", "Targets format [legacy, json]")
 	fs.StringVar(&opts.outputf, "output", "stdout", "Output file")
 	fs.StringVar(&opts.bodyf, "body", "", "Requests body file")
 	fs.StringVar(&opts.certf, "cert", "", "TLS client PEM encoded certificate file")
@@ -115,7 +115,11 @@ func attack(opts *attackOpts) (err error) {
 	)
 
 	switch opts.format {
+	case "json":
+		tr = vegeta.NewJSONTargeter(src, body, hdr)
 	case "legacy":
+		fallthrough
+	default:
 		tr = vegeta.NewLegacyTargeter(src, body, hdr)
 	}
 

--- a/attack.go
+++ b/attack.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
 	vegeta "github.com/tsenart/vegeta/lib"
@@ -25,7 +26,8 @@ func attackCmd() command {
 
 	fs.StringVar(&opts.name, "name", "", "Attack name")
 	fs.StringVar(&opts.targetsf, "targets", "stdin", "Targets file")
-	fs.StringVar(&opts.format, "format", "http", "Targets format [http, json]")
+	fs.StringVar(&opts.format, "format", vegeta.HTTPTargetFormat,
+		fmt.Sprintf("Targets format [%s]", strings.Join(vegeta.TargetFormats, ", ")))
 	fs.StringVar(&opts.outputf, "output", "stdout", "Output file")
 	fs.StringVar(&opts.bodyf, "body", "", "Requests body file")
 	fs.StringVar(&opts.certf, "cert", "", "TLS client PEM encoded certificate file")
@@ -115,13 +117,13 @@ func attack(opts *attackOpts) (err error) {
 	)
 
 	switch opts.format {
-	case "json":
+	case vegeta.JSONTargetFormat:
 		tr = vegeta.NewJSONTargeter(src, body, hdr)
-	case "http":
+	case vegeta.HTTPTargetFormat:
 		tr = vegeta.NewHTTPTargeter(src, body, hdr)
 	default:
-		valid := [...]string{vegeta.HTTPTargetFormat, vegeta.JSONTargetFormat}
-		return fmt.Errorf("format %q isn't one of %v", opts.format, valid)
+		return fmt.Errorf("format %q isn't one of [%s]",
+			opts.format, strings.Join(vegeta.TargetFormats, ", "))
 	}
 
 	if !opts.lazy {

--- a/attack.go
+++ b/attack.go
@@ -25,7 +25,7 @@ func attackCmd() command {
 
 	fs.StringVar(&opts.name, "name", "", "Attack name")
 	fs.StringVar(&opts.targetsf, "targets", "stdin", "Targets file")
-	fs.StringVar(&opts.format, "format", "legacy", "Targets format [legacy, json]")
+	fs.StringVar(&opts.format, "format", "http", "Targets format [http, json]")
 	fs.StringVar(&opts.outputf, "output", "stdout", "Output file")
 	fs.StringVar(&opts.bodyf, "body", "", "Requests body file")
 	fs.StringVar(&opts.certf, "cert", "", "TLS client PEM encoded certificate file")
@@ -117,10 +117,10 @@ func attack(opts *attackOpts) (err error) {
 	switch opts.format {
 	case "json":
 		tr = vegeta.NewJSONTargeter(src, body, hdr)
-	case "legacy":
+	case "http":
 		fallthrough
 	default:
-		tr = vegeta.NewLegacyTargeter(src, body, hdr)
+		tr = vegeta.NewHTTPTargeter(src, body, hdr)
 	}
 
 	if !opts.lazy {

--- a/internal/cmd/jsonschema/main.go
+++ b/internal/cmd/jsonschema/main.go
@@ -20,11 +20,13 @@ func main() {
 
 	valid := strings.Join(keys(types), ", ")
 
-	fs := flag.NewFlagSet("jsonschema", flag.ExitOnError)
+	fs := flag.NewFlagSet("jsonschema", flag.ContinueOnError)
 	typ := fs.String("type", "", fmt.Sprintf("Vegeta type to generate a JSON schema for [%s]", valid))
 	out := fs.String("output", "stdout", "Output file")
 
-	fs.Parse(os.Args[1:])
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		die("%s", err)
+	}
 
 	t, ok := types[*typ]
 	if !ok {

--- a/internal/cmd/jsonschema/main.go
+++ b/internal/cmd/jsonschema/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/alecthomas/jsonschema"
+
+	vegeta "github.com/tsenart/vegeta/lib"
+)
+
+func main() {
+	types := map[string]interface{}{
+		"Target": &vegeta.Target{},
+	}
+
+	valid := strings.Join(keys(types), ", ")
+
+	fs := flag.NewFlagSet("jsonschema", flag.ExitOnError)
+	typ := fs.String("type", "", fmt.Sprintf("Vegeta type to generate a JSON schema for [%s]", valid))
+	out := fs.String("output", "stdout", "Output file")
+
+	fs.Parse(os.Args[1:])
+
+	t, ok := types[*typ]
+	if !ok {
+		die("invalid type %q not in [%s]", *typ, valid)
+	}
+
+	schema, err := json.MarshalIndent(jsonschema.Reflect(t), "", "  ")
+	if err != nil {
+		die("%s", err)
+	}
+
+	switch *out {
+	case "stdout":
+		_, err = os.Stdout.Write(schema)
+	default:
+		err = ioutil.WriteFile(*out, schema, 0644)
+	}
+
+	if err != nil {
+		die("%s", err)
+	}
+}
+
+func die(s string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, s, args...)
+	os.Exit(1)
+}
+
+func keys(types map[string]interface{}) (ks []string) {
+	for k := range types {
+		ks = append(ks, k)
+	}
+	return ks
+}

--- a/lib/target.schema.json
+++ b/lib/target.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/Target",
+  "definitions": {
+    "Target": {
+      "required": [
+        "method",
+        "url"
+      ],
+      "properties": {
+        "body": {
+          "type": "string",
+          "media": {
+            "binaryEncoding": "base64"
+          }
+        },
+        "header": {
+          "patternProperties": {
+            ".*": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "method": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/lib/targets.go
+++ b/lib/targets.go
@@ -46,6 +46,9 @@ var (
 	ErrNoTargets = errors.New("no targets to attack")
 	// ErrNilTarget is returned when the passed Target pointer is nil.
 	ErrNilTarget = errors.New("nil target")
+	// TargetFormats contains the canonical list of the valid target
+	// format identifiers.
+	TargetFormats = []string{HTTPTargetFormat, JSONTargetFormat}
 )
 
 const (

--- a/lib/targets.go
+++ b/lib/targets.go
@@ -178,16 +178,10 @@ func NewStaticTargeter(tgts ...Target) Targeter {
 	}
 }
 
-// NewEagerTargeter eagerly reads all Targets out of the provided Targeter and
-// returns a NewStaticTargeter with them.
-func NewEagerTargeter(t Targeter) (Targeter, error) {
-	var (
-		tgts []Target
-		tgt  Target
-		err  error
-	)
-
+// ReadAllTargets eagerly reads all Targets out of the provided Targeter.
+func ReadAllTargets(t Targeter) (tgts []Target, err error) {
 	for {
+		var tgt Target
 		if err = t(&tgt); err == ErrNoTargets {
 			break
 		} else if err != nil {
@@ -200,7 +194,7 @@ func NewEagerTargeter(t Targeter) (Targeter, error) {
 		return nil, ErrNoTargets
 	}
 
-	return NewStaticTargeter(tgts...), nil
+	return tgts, nil
 }
 
 // NewHTTPTargeter returns a new Targeter that decodes one Target from the

--- a/lib/targets.go
+++ b/lib/targets.go
@@ -48,6 +48,13 @@ var (
 	ErrNilTarget = errors.New("nil target")
 )
 
+const (
+	// HTTPTargetFormat is the human readable identifier for the HTTP target format.
+	HTTPTargetFormat = "http"
+	// JSONTargetFormat is the human readable identifier for the JSON target format.
+	JSONTargetFormat = "json"
+)
+
 // A Targeter decodes a Target or returns an error in case of failure.
 // Implementations must be safe for concurrent use.
 type Targeter func(*Target) error

--- a/lib/targets.go
+++ b/lib/targets.go
@@ -17,11 +17,13 @@ import (
 )
 
 // Target is an HTTP request blueprint.
+//
+//go:generate jsonschema -type=Target -output=target.schema.json
 type Target struct {
 	Method string      `json:"method"`
 	URL    string      `json:"url"`
-	Body   []byte      `json:"body"`
-	Header http.Header `json:"header"`
+	Body   []byte      `json:"body,omitempty"`
+	Header http.Header `json:"header,omitempty"`
 }
 
 // Request creates an *http.Request out of Target and returns it along with an
@@ -64,7 +66,9 @@ type Targeter func(*Target) error
 
 // NewJSONTargeter returns a new targeter that decodes one Target from the
 // given io.Reader on every invocation. Each target is one JSON object in its own line.
-// The body field of each target must be base64 encoded.
+//
+// The method and url fields are required. If present, the body field must be base64 encoded.
+// The generated [JSON Schema](lib/target.schema.json) defines the format in detail.
 //
 //    {"method":"POST", "url":"https://goku/1", "header":{"Content-Type":["text/plain"], "body": "Rk9P"}
 //    {"method":"GET",  "url":"https://goku/2"}

--- a/lib/targets.go
+++ b/lib/targets.go
@@ -128,7 +128,7 @@ func NewEagerTargeter(t Targeter) (Targeter, error) {
 	return NewStaticTargeter(tgts...), nil
 }
 
-// NewLegacyTargeter returns a new Targeter that decodes one Target from the
+// NewHTTPTargeter returns a new Targeter that decodes one Target from the
 // given io.Reader on every invocation. The format is as follows:
 //
 //    GET https://foo.bar/a/b/c
@@ -141,7 +141,7 @@ func NewEagerTargeter(t Targeter) (Targeter, error) {
 //
 // body will be set as the Target's body if no body is provided.
 // hdr will be merged with the each Target's headers.
-func NewLegacyTargeter(src io.Reader, body []byte, hdr http.Header) Targeter {
+func NewHTTPTargeter(src io.Reader, body []byte, hdr http.Header) Targeter {
 	var mu sync.Mutex
 	sc := peekingScanner{src: bufio.NewScanner(src)}
 	return func(tgt *Target) (err error) {

--- a/lib/targets_test.go
+++ b/lib/targets_test.go
@@ -62,7 +62,7 @@ func TestNewEagerTargeter(t *testing.T) {
 	t.Parallel()
 
 	src := []byte("GET http://:6060/\nHEAD http://:6606/")
-	read, err := NewEagerTargeter(NewLegacyTargeter(bytes.NewReader(src), []byte("body"), nil))
+	read, err := NewEagerTargeter(NewHTTPTargeter(bytes.NewReader(src), []byte("body"), nil))
 	if err != nil {
 		t.Fatalf("Couldn't parse valid source: %s", err)
 	}
@@ -89,7 +89,7 @@ func TestNewEagerTargeter(t *testing.T) {
 	}
 }
 
-func TestNewLegacyTargeter(t *testing.T) {
+func TestNewHTTPTargeter(t *testing.T) {
 	t.Parallel()
 
 	for want, def := range map[error]string{
@@ -111,7 +111,7 @@ func TestNewLegacyTargeter(t *testing.T) {
 			: 1234`,
 	} {
 		src := bytes.NewBufferString(strings.TrimSpace(def))
-		read := NewLegacyTargeter(src, []byte{}, http.Header{})
+		read := NewHTTPTargeter(src, []byte{}, http.Header{})
 		if got := read(&Target{}); got == nil || !strings.HasPrefix(got.Error(), want.Error()) {
 			t.Errorf("got: %s, want: %s\n%s", got, want, def)
 		}
@@ -149,7 +149,7 @@ func TestNewLegacyTargeter(t *testing.T) {
 	)
 
 	src := bytes.NewBufferString(strings.TrimSpace(targets))
-	read := NewLegacyTargeter(src, []byte{}, http.Header{"Content-Type": []string{"text/plain"}})
+	read := NewHTTPTargeter(src, []byte{}, http.Header{"Content-Type": []string{"text/plain"}})
 	for _, want := range []Target{
 		{
 			Method: "GET",
@@ -215,13 +215,13 @@ func TestNewLegacyTargeter(t *testing.T) {
 func TestErrNilTarget(t *testing.T) {
 	t.Parallel()
 
-	eager, err := NewEagerTargeter(NewLegacyTargeter(strings.NewReader("GET http://foo.bar"), nil, nil))
+	eager, err := NewEagerTargeter(NewHTTPTargeter(strings.NewReader("GET http://foo.bar"), nil, nil))
 	if err != nil {
 		t.Fatal(err)
 	}
 	for i, tr := range []Targeter{
 		NewStaticTargeter(Target{Method: "GET", URL: "http://foo.bar"}),
-		NewLegacyTargeter(strings.NewReader("GET http://foo.bar"), nil, nil),
+		NewHTTPTargeter(strings.NewReader("GET http://foo.bar"), nil, nil),
 		eager,
 	} {
 		if got, want := tr(nil), ErrNilTarget; got != want {


### PR DESCRIPTION
#### Background

The original targets format closely resembles plain HTTP/1.x messages. It was meant to be used by humans writing those targets directly on their terminals. With its lack of support for in-line body definitions, this ill-defined legacy format made Vegeta hard to integrate with other programs generating dynamic targets on the fly with distinct request bodies.

Extending the legacy format to support arbitrary in-line request bodies would require further deviation from the HTTP/1.x message format since, to the best of my knowledge, there is no official plain text framing format that would allow the boundaries between multiple targets with arbitrary request bodies to be easily recognized (and hence, parsed).

It could be done, certainly, but for the use case of integrating Vegeta with other programs generating targets, I think a simpler alternative JSON based format could be better.

This PR proposes just such a format and is intended to gather feedback from interested parties.

It's currently a work-in-progress, but the CLI interface is already specified and documented.

Please provide feedback: @coxx, @1u0, @mbrookes1304, @cwinters, @xla.

##### Related Issues and PRs

- https://github.com/tsenart/vegeta/pull/148
- https://github.com/tsenart/vegeta/pull/260
- https://github.com/tsenart/vegeta/issues/298

#### Checklist

- [x] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] Each Git commit represents meaningful milestones or atomic units of work.
- [x] Changed or added code is covered by appropriate tests.
