### PR TITLE
metrics: Adopt T-Digest for streaming quantile estimation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -9,6 +9,24 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/bmizerany/perks"
+  packages = ["quantile"]
+  revision = "d9a9656a3a4b1c2864fdb44db2ef8619772d92aa"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/dgryski/go-gk"
+  packages = ["."]
+  revision = "201884a44051d8544b65e6b1c05ae71c0c45b9e0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/influxdata/tdigest"
+  packages = ["."]
+  revision = "617b83f940fd9acd207f712561a8a0590277fb38"
+
+[[projects]]
+  branch = "master"
   name = "github.com/lucasb-eyer/go-colorful"
   packages = ["."]
   revision = "8abd3beca3a7f5039809449d6013a0254ac22bb1"
@@ -54,6 +72,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b7241bb8cec207e1b751be687240fd7f6af51a3a9e37a70c4d62c33a96c1391e"
+  inputs-digest = "3f57915bac2b6a24d1d9bd8e2eda4e30f5b8ccd57e54192bac724c4368892009"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -23,13 +23,13 @@
   branch = "master"
   name = "github.com/influxdata/tdigest"
   packages = ["."]
-  revision = "617b83f940fd9acd207f712561a8a0590277fb38"
+  revision = "a7d76c6f093a59b94a01c6c2b8429122d444a8cc"
 
 [[projects]]
-  branch = "master"
   name = "github.com/lucasb-eyer/go-colorful"
   packages = ["."]
-  revision = "8abd3beca3a7f5039809449d6013a0254ac22bb1"
+  revision = "345fbb3dbcdb252d9985ee899a84963c0fa24c82"
+  version = "v1.0"
 
 [[projects]]
   branch = "master"
@@ -46,7 +46,7 @@
     "http2/hpack",
     "idna"
   ]
-  revision = "2491c5de3490fced2f6cff376127c667efeed857"
+  revision = "d0887baf81f4598189d4e12a37c6da86f0bba4d0"
 
 [[projects]]
   name = "golang.org/x/text"
@@ -72,6 +72,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3f57915bac2b6a24d1d9bd8e2eda4e30f5b8ccd57e54192bac724c4368892009"
+  inputs-digest = "fb39a677ce103160b5e8e1ece09b716da865a11999666a24d5839633e33d8588"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,6 +27,26 @@
 
 [[constraint]]
   branch = "master"
+  name = "github.com/alecthomas/jsonschema"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/bmizerany/perks"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/dgryski/go-gk"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/influxdata/tdigest"
+
+[[constraint]]
+  name = "github.com/lucasb-eyer/go-colorful"
+  version = "1.0.0"
+
+[[constraint]]
+  branch = "master"
   name = "github.com/streadway/quantile"
 
 [[constraint]]

--- a/lib/metrics.go
+++ b/lib/metrics.go
@@ -39,7 +39,7 @@ type Metrics struct {
 
 	errors    map[string]struct{}
 	success   uint64
-	latencies *quantile.Estimator
+	latencies estimator
 }
 
 // LatencyMetrics holds computed request latency metrics.
@@ -146,4 +146,9 @@ func (m *Metrics) init() {
 	if m.Errors == nil {
 		m.Errors = make([]string, 0)
 	}
+}
+
+type estimator interface {
+	Add(s float64)
+	Get(q float64) float64
 }

--- a/lib/metrics.go
+++ b/lib/metrics.go
@@ -136,6 +136,8 @@ func (m *Metrics) init() {
 	}
 
 	if m.latencies == nil {
+		// This compression parameter value is the recommended value
+		// for normal uses as per http://javadox.com/com.tdunning/t-digest/3.0/com/tdunning/math/stats/TDigest.html
 		m.latencies = newTdigestEstimator(100)
 	}
 

--- a/lib/metrics.go
+++ b/lib/metrics.go
@@ -37,33 +37,8 @@ type Metrics struct {
 	// Errors is a set of unique errors returned by the targets during the attack.
 	Errors []string `json:"errors"`
 
-	errors    map[string]struct{}
-	success   uint64
-	latencies estimator
-}
-
-// LatencyMetrics holds computed request latency metrics.
-type LatencyMetrics struct {
-	// Total is the total latency sum of all requests in an attack.
-	Total time.Duration `json:"total"`
-	// Mean is the mean request latency.
-	Mean time.Duration `json:"mean"`
-	// P50 is the 50th percentile request latency.
-	P50 time.Duration `json:"50th"`
-	// P95 is the 95th percentile request latency.
-	P95 time.Duration `json:"95th"`
-	// P99 is the 99th percentile request latency.
-	P99 time.Duration `json:"99th"`
-	// Max is the maximum observed request latency.
-	Max time.Duration `json:"max"`
-}
-
-// ByteMetrics holds computed byte flow metrics.
-type ByteMetrics struct {
-	// Total is the total number of flowing bytes in an attack.
-	Total uint64 `json:"total"`
-	// Mean is the mean number of flowing bytes per hit.
-	Mean float64 `json:"mean"`
+	errors  map[string]struct{}
+	success uint64
 }
 
 // Add implements the Add method of the Report interface by adding the given
@@ -73,11 +48,10 @@ func (m *Metrics) Add(r *Result) {
 
 	m.Requests++
 	m.StatusCodes[strconv.Itoa(int(r.Code))]++
-	m.Latencies.Total += r.Latency
 	m.BytesOut.Total += r.BytesOut
 	m.BytesIn.Total += r.BytesIn
 
-	m.latencies.Add(float64(r.Latency))
+	m.Latencies.Add(r.Latency)
 
 	if m.Earliest.IsZero() || m.Earliest.After(r.Timestamp) {
 		m.Earliest = r.Timestamp
@@ -89,10 +63,6 @@ func (m *Metrics) Add(r *Result) {
 
 	if end := r.End(); end.After(m.End) {
 		m.End = end
-	}
-
-	if r.Latency > m.Latencies.Max {
-		m.Latencies.Max = r.Latency
 	}
 
 	if r.Code >= 200 && r.Code < 400 {
@@ -121,9 +91,9 @@ func (m *Metrics) Close() {
 	m.BytesOut.Mean = float64(m.BytesOut.Total) / float64(m.Requests)
 	m.Success = float64(m.success) / float64(m.Requests)
 	m.Latencies.Mean = time.Duration(float64(m.Latencies.Total) / float64(m.Requests))
-	m.Latencies.P50 = time.Duration(m.latencies.Get(0.50))
-	m.Latencies.P95 = time.Duration(m.latencies.Get(0.95))
-	m.Latencies.P99 = time.Duration(m.latencies.Get(0.99))
+	m.Latencies.P50 = m.Latencies.Quantile(0.50)
+	m.Latencies.P95 = m.Latencies.Quantile(0.95)
+	m.Latencies.P99 = m.Latencies.Quantile(0.99)
 }
 
 func (m *Metrics) init() {
@@ -135,15 +105,58 @@ func (m *Metrics) init() {
 		m.errors = map[string]struct{}{}
 	}
 
-	if m.latencies == nil {
-		// This compression parameter value is the recommended value
-		// for normal uses as per http://javadox.com/com.tdunning/t-digest/3.0/com/tdunning/math/stats/TDigest.html
-		m.latencies = newTdigestEstimator(100)
-	}
-
 	if m.Errors == nil {
 		m.Errors = make([]string, 0)
 	}
+}
+
+// LatencyMetrics holds computed request latency metrics.
+type LatencyMetrics struct {
+	// Total is the total latency sum of all requests in an attack.
+	Total time.Duration `json:"total"`
+	// Mean is the mean request latency.
+	Mean time.Duration `json:"mean"`
+	// P50 is the 50th percentile request latency.
+	P50 time.Duration `json:"50th"`
+	// P95 is the 95th percentile request latency.
+	P95 time.Duration `json:"95th"`
+	// P99 is the 99th percentile request latency.
+	P99 time.Duration `json:"99th"`
+	// Max is the maximum observed request latency.
+	Max time.Duration `json:"max"`
+
+	estimator estimator
+}
+
+// Add adds the given latency to the latency metrics.
+func (l *LatencyMetrics) Add(latency time.Duration) {
+	l.init()
+	if l.Total += latency; latency > l.Max {
+		l.Max = latency
+	}
+	l.estimator.Add(float64(latency))
+}
+
+// Quantile returns the nth quantile from the latency summary.
+func (l LatencyMetrics) Quantile(nth float64) time.Duration {
+	l.init()
+	return time.Duration(l.estimator.Get(nth))
+}
+
+func (l *LatencyMetrics) init() {
+	if l.estimator == nil {
+		// This compression parameter value is the recommended value
+		// for normal uses as per http://javadox.com/com.tdunning/t-digest/3.0/com/tdunning/math/stats/TDigest.html
+		l.estimator = newTdigestEstimator(100)
+	}
+}
+
+// ByteMetrics holds computed byte flow metrics.
+type ByteMetrics struct {
+	// Total is the total number of flowing bytes in an attack.
+	Total uint64 `json:"total"`
+	// Mean is the mean number of flowing bytes per hit.
+	Mean float64 `json:"mean"`
 }
 
 type estimator interface {

--- a/lib/metrics.go
+++ b/lib/metrics.go
@@ -167,7 +167,7 @@ type estimator interface {
 type tdigestEstimator struct{ *tdigest.TDigest }
 
 func newTdigestEstimator(compression float64) *tdigestEstimator {
-	return &tdigestEstimator{tdigest.NewWithCompression(compression)}
+	return &tdigestEstimator{TDigest: tdigest.NewWithCompression(compression)}
 }
 
 func (e *tdigestEstimator) Add(s float64) { e.TDigest.Add(s, 1) }

--- a/lib/metrics_test.go
+++ b/lib/metrics_test.go
@@ -152,7 +152,7 @@ type bmizeranyEstimator struct {
 }
 
 func newBmizeranyEstimator(qs ...float64) *bmizeranyEstimator {
-	return &bmizeranyEstimator{bmizerany.NewTargeted(qs...)}
+	return &bmizeranyEstimator{Stream: bmizerany.NewTargeted(qs...)}
 }
 
 func (e *bmizeranyEstimator) Add(s float64) { e.Insert(s) }
@@ -165,7 +165,7 @@ type dgryskiEstimator struct {
 }
 
 func newDgriskyEstimator(epsilon float64) *dgryskiEstimator {
-	return &dgryskiEstimator{gk.New(epsilon)}
+	return &dgryskiEstimator{Stream: gk.New(epsilon)}
 }
 
 func (e *dgryskiEstimator) Add(s float64) { e.Insert(s) }

--- a/lib/metrics_test.go
+++ b/lib/metrics_test.go
@@ -40,12 +40,13 @@ func TestMetrics_Add(t *testing.T) {
 
 	want := Metrics{
 		Latencies: LatencyMetrics{
-			Total: duration("50.005s"),
-			Mean:  duration("5.0005ms"),
-			P50:   duration("5.0005ms"),
-			P95:   duration("9.5005ms"),
-			P99:   duration("9.9005ms"),
-			Max:   duration("10ms"),
+			Total:     duration("50.005s"),
+			Mean:      duration("5.0005ms"),
+			P50:       duration("5.0005ms"),
+			P95:       duration("9.5005ms"),
+			P99:       duration("9.9005ms"),
+			Max:       duration("10ms"),
+			estimator: got.Latencies.estimator,
 		},
 		BytesIn:     ByteMetrics{Total: 10240000, Mean: 1024},
 		BytesOut:    ByteMetrics{Total: 5120000, Mean: 512},
@@ -60,9 +61,8 @@ func TestMetrics_Add(t *testing.T) {
 		StatusCodes: map[string]int{"500": 3333, "200": 3334, "302": 3333},
 		Errors:      []string{"Internal server error"},
 
-		errors:    got.errors,
-		success:   got.success,
-		latencies: got.latencies,
+		errors:  got.errors,
+		success: got.success,
 	}
 
 	if !reflect.DeepEqual(got, want) {
@@ -124,7 +124,7 @@ func BenchmarkMetrics(b *testing.B) {
 		{"dgrisky/go-gk", newDgriskyEstimator(0.5)},
 		{"influxdata/tdigest", newTdigestEstimator(100)},
 	} {
-		m := Metrics{latencies: tc.estimator}
+		m := Metrics{Latencies: LatencyMetrics{estimator: tc.estimator}}
 		b.Run("Add/"+tc.name, func(b *testing.B) {
 			for i := 0; i <= b.N; i++ {
 				m.Add(&Result{


### PR DESCRIPTION
#### Background

Benchmarking the current generation of streaming quantile libraries in Go has revealed https://github.com/influxdata/tdigest as the winner in performance without sacrificing expected levels of accuracy for the common quantiles. With this library, the 50th percentile is the one that may be less precise among all.

After this is merged, we can follow up with https://github.com/tsenart/vegeta/pull/268

#### Checklist

- [x] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] Each Git commit represents meaningful milestones or atomic units of work.
- [x] Changed or added code is covered by appropriate tests.
