### PR TITLE
README: Document semantic versioning split

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ command:
 $ go get -u github.com/tsenart/vegeta
 ```
 
+## Versioning
+Both the library and the CLI are versioned with [SemVer v2.0.0](https://semver.org/spec/v2.0.0.html).
+
+After [v8.0.0](https://github.com/tsenart/vegeta/tree/v8.0.0), the two components
+are versioned separately to better isolate breaking changes to each.
+
+CLI releases are tagged with `cli-vMAJOR.MINOR.PATCH` and published on the [Github releases page](https://github.com/tsenart/vegeta/releases).
+As for the library, new versions are tagged with `lib-vMAJOR.MINOR.PATCH` but not published as a release.
+
 ## Contributing
 See [CONTRIBUTING.md](CONTRIBUTING.md).
 
@@ -425,6 +434,11 @@ echo 'GET http://localhost:8080' | \
 ![](https://i.imgur.com/ttBDsQS.gif)
 
 ## Usage (Library)
+
+The library versioning follows [SemVer v2.0.0](https://semver.org/spec/v2.0.0.html).
+Since [lib-v9.0.0](https://github.com/tsenart/vegeta/tree/lib-v9.0.0), the library and cli
+are versioned separately to better isolate breaking changes to each component.
+
 ```go
 package main
 


### PR DESCRIPTION
#### Background

Having two projects in one (mono) repo without separate versioning namespaces has led to breaking changes in one to affect the semantic versioning of both unintentionally. In order to isolate the signaling of breaking changes in each component, we're introducing versioning namespaces.

- `lib-vMAJOR.MINOR.PATCH` for library versions
- `cli-vMAJOR.MINOR.PATCH` for CLI versions

Henceforth, the two have versions that progress independently.