### PR TITLE
Fix using ReadAllTagets with JSONTargeter

### DIFF
--- a/lib/targets.go
+++ b/lib/targets.go
@@ -131,7 +131,10 @@ func NewJSONTargeter(src io.Reader, body []byte, header http.Header) Targeter {
 		defer dec.Unlock()
 
 		var t Target
-		if err = dec.Decode(&t); err != nil && err != io.EOF {
+		if err = dec.Decode(&t); err != nil {
+			if err == io.EOF {
+				err = ErrNoTargets
+			}
 			return err
 		} else if t.Method == "" {
 			return ErrNoMethod
@@ -155,10 +158,6 @@ func NewJSONTargeter(src io.Reader, body []byte, header http.Header) Targeter {
 
 		for k, vs := range t.Header {
 			tgt.Header[k] = append(tgt.Header[k], vs...)
-		}
-
-		if err == io.EOF {
-			err = ErrNoTargets
 		}
 
 		return err


### PR DESCRIPTION
#### Background

Self explanatory, NewJSONTargeter returns a targeter that cannot throw ErrNoTargets and thus will always error when used with ReadAllTargets.

#### Checklist

- [x] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] Each Git commit represents meaningful milestones or atomic units of work.
- [x] Changed or added code is covered by appropriate tests.
