### PR TITLE
targets: Fix JSONTargeter EOF detection

### DIFF
--- a/lib/targets.go
+++ b/lib/targets.go
@@ -131,7 +131,10 @@ func NewJSONTargeter(src io.Reader, body []byte, header http.Header) Targeter {
 		defer dec.Unlock()
 
 		var t Target
-		if err = dec.Decode(&t); err != nil && err != io.EOF {
+		if err = dec.Decode(&t); err != nil {
+			if err == io.EOF {
+				err = ErrNoTargets
+			}
 			return err
 		} else if t.Method == "" {
 			return ErrNoMethod
@@ -155,10 +158,6 @@ func NewJSONTargeter(src io.Reader, body []byte, header http.Header) Targeter {
 
 		for k, vs := range t.Header {
 			tgt.Header[k] = append(tgt.Header[k], vs...)
-		}
-
-		if err == io.EOF {
-			err = ErrNoTargets
 		}
 
 		return err


### PR DESCRIPTION
#### Background

The recently introduced `JSONTargeter` doesn't return `ErrNoTargets` on the last target read in a stream. This resulted in `ReadAllTargets` to not work with it as well as single Targets from the command line like the [README exemplifies](https://github.com/tsenart/vegeta/blob/master/README.md#json-format).

Related issues and PRs:
- https://github.com/tsenart/vegeta/issues/310
- https://github.com/tsenart/vegeta/pull/311

This PR fixes these issues. We'll also follow up on reducing the likelihood of this kind of bug from happening by creating an integration test suite for the CLI. This effort has been captured in #312.

#### Checklist

- [ ] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] Each Git commit represents meaningful milestones or atomic units of work.
- [ ] Changed or added code is covered by appropriate tests.
