### PR TITLE
Consistent multiple file argument handling across plot, report and encode.

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
 	"io"
@@ -59,42 +58,11 @@ func encodeCmd() command {
 }
 
 func encode(files []string, to, output string) error {
-	srcs := make([]vegeta.Decoder, len(files))
-	decs := []func(io.Reader) vegeta.Decoder{
-		vegeta.NewDecoder,
-		vegeta.NewJSONDecoder,
-		vegeta.NewCSVDecoder,
+	dec, mc, err := decoder(files)
+	defer mc.Close()
+	if err != nil {
+		return err
 	}
-
-	for i, f := range files {
-		in, err := file(f, false)
-		if err != nil {
-			return err
-		}
-		defer in.Close()
-
-		// Auto-detect encoding of each file individually and buffer the read bytes
-		// so that they can be read in subsequent decoding attempts as well as
-		// in the final decoder.
-
-		var buf bytes.Buffer
-		var dec func(io.Reader) vegeta.Decoder
-		for j := range decs {
-			rd := io.MultiReader(bytes.NewReader(buf.Bytes()), io.TeeReader(in, &buf))
-			if err = decs[j](rd).Decode(&vegeta.Result{}); err == nil {
-				dec = decs[j]
-				break
-			}
-		}
-
-		if dec == nil {
-			return fmt.Errorf("encode: can't detect encoding of %q", f)
-		}
-
-		srcs[i] = dec(io.MultiReader(&buf, in))
-	}
-
-	dec := vegeta.NewRoundRobinDecoder(srcs...)
 
 	out, err := file(output, true)
 	if err != nil {

--- a/encode.go
+++ b/encode.go
@@ -24,6 +24,18 @@ The supported encodings are Gob (binary), CSV and JSON.
 Each input file may have a different encoding which is detected
 automatically.
 
+The CSV encoder doesn't write a header. The columns written by it are:
+
+  1. Unix timestamp in nanoseconds since epoch
+  2. HTTP status code
+  3. Request latency in nanoseconds
+  4. Bytes out
+  5. Bytes in
+  6. Error
+  7. Base64 encoded response body
+  8. Attack name
+  9. Sequence number of request
+
 Arguments:
   <file>  A file with vegeta attack results encoded with one of
           the supported encodings (gob | json | csv) [default: stdin]

--- a/main.go
+++ b/main.go
@@ -101,10 +101,9 @@ var Version, Commit, Date string
 const examples = `
 examples:
   echo "GET http://localhost/" | vegeta attack -duration=5s | tee results.bin | vegeta report
-  vegeta attack -targets=targets.txt > results.bin
-  vegeta report -inputs=results.bin -reporter=json > metrics.json
+  vegeta report -type=json results.bin > metrics.json
   cat results.bin | vegeta plot > plot.html
-  cat results.bin | vegeta report -reporter="hist[0,100ms,200ms,300ms]"
+  cat results.bin | vegeta report -type="hist[0,100ms,200ms,300ms]"
 `
 
 type command struct {

--- a/plot.go
+++ b/plot.go
@@ -60,16 +60,11 @@ func plotCmd() command {
 }
 
 func plotRun(files []string, threshold int, title, output string) error {
-	srcs := make([]vegeta.Decoder, len(files))
-	for i, f := range files {
-		in, err := file(f, false)
-		if err != nil {
-			return err
-		}
-		defer in.Close()
-		srcs[i] = vegeta.NewDecoder(in)
+	dec, mc, err := decoder(files)
+	defer mc.Close()
+	if err != nil {
+		return err
 	}
-	dec := vegeta.NewRoundRobinDecoder(srcs...)
 
 	out, err := file(output, true)
 	if err != nil {

--- a/plot.go
+++ b/plot.go
@@ -23,7 +23,8 @@ Choose a different number on the bottom left corner input field
 to change the moving average window size (in data points).
 
 Arguments:
-  <file>  A file output by running vegeta attack [default: stdin]
+  <file>  A file with vegeta attack results encoded with one of
+          the supported encodings (gob | json | csv) [default: stdin]
 
 Options:
   --title      Title and header of the resulting HTML page.


### PR DESCRIPTION
With the goal to improve UX of the vegeta toolchain, this change aligns the behaviour of the `report`, `encode` and `plot` commands so that they can all read multiple input files of different encodings.

Fixes #255
