### PR TITLE
attack: Support response body read limits

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,84 +3,115 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:c312c313bb8040fcfb5698f38b51ec279e4635c7619773e6f018c908586c64b1"
   name = "github.com/alecthomas/jsonschema"
   packages = ["."]
+  pruneopts = "UT"
   revision = "f2c93856175a7dd6abe88c5c3900b67ad054adcc"
 
 [[projects]]
   branch = "master"
+  digest = "1:f31b92722c6eca05df9ba28e9cb38d94de0865f034fff164557f103d6d13b612"
   name = "github.com/bmizerany/perks"
   packages = ["quantile"]
+  pruneopts = "UT"
   revision = "d9a9656a3a4b1c2864fdb44db2ef8619772d92aa"
 
 [[projects]]
   branch = "master"
+  digest = "1:e8891cd354f2af940345f895d5698ab1ed439196d4f69eb44817fc91e80354c1"
+  name = "github.com/c2h5oh/datasize"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "4eba002a5eaea69cf8d235a388fc6b65ae68d2dd"
+
+[[projects]]
+  branch = "master"
+  digest = "1:5c4cefdd3ba39aee4e4b6f9aad121a79fd2a989b9b54acbe4f530cc3a700cd75"
   name = "github.com/dgryski/go-gk"
   packages = ["."]
+  pruneopts = "UT"
   revision = "201884a44051d8544b65e6b1c05ae71c0c45b9e0"
 
 [[projects]]
   branch = "master"
+  digest = "1:bc4e2b6c1af97c03fe850864bf22574abc6ad0fcbf0e5dda0fd246d3d43f9ccb"
   name = "github.com/dgryski/go-lttb"
   packages = ["."]
+  pruneopts = "UT"
   revision = "318fcdf10a77c2df09d83777e41f5e18d236ec9d"
 
 [[projects]]
+  digest = "1:2e3c336fc7fde5c984d2841455a658a6d626450b1754a854b3b32e7a8f49a07a"
   name = "github.com/google/go-cmp"
   packages = [
     "cmp",
     "cmp/internal/diff",
     "cmp/internal/function",
-    "cmp/internal/value"
+    "cmp/internal/value",
   ]
+  pruneopts = "UT"
   revision = "3af367b6b30c263d47e8895973edcca9a49cf029"
   version = "v0.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:b07e7ba2bb99a70ce3318ea387a62666371c1ab4f9bfcae192a59e3f4b8ffa56"
   name = "github.com/influxdata/tdigest"
   packages = ["."]
+  pruneopts = "UT"
   revision = "a7d76c6f093a59b94a01c6c2b8429122d444a8cc"
 
 [[projects]]
   branch = "master"
+  digest = "1:7ca2584fa7da0520cd2d1136a10194fe5a5b220bdb215074ab6f7b5ad91115f4"
   name = "github.com/shurcooL/httpfs"
   packages = ["vfsutil"]
+  pruneopts = "UT"
   revision = "809beceb23714880abc4a382a00c05f89d13b1cc"
 
 [[projects]]
   branch = "master"
+  digest = "1:b5db31f108c72b9de4e36ca3222a4e325beebfa492a9d3f62f313ffa9cdab3b7"
   name = "github.com/shurcooL/vfsgen"
   packages = ["."]
+  pruneopts = "UT"
   revision = "62bca832be04bd2bcaabd3b68a6b19a7ec044411"
 
 [[projects]]
   branch = "master"
+  digest = "1:383e656d30a7bd2c663514940748c189307134c65ec8c7b2070ed01abb93e73d"
   name = "github.com/streadway/quantile"
   packages = ["."]
+  pruneopts = "UT"
   revision = "b0c588724d25ae13f5afb3d90efec0edc636432b"
 
 [[projects]]
   branch = "master"
+  digest = "1:be87c1e6f0a15e5b1c45036b9382cdd63057a8b65e10ff2fe2bda23886a99c6a"
   name = "github.com/tsenart/go-tsz"
   packages = [
     ".",
-    "testdata"
+    "testdata",
   ]
+  pruneopts = "UT"
   revision = "cdeb9e1e981e85dafc95428f5da9cba59cbcc828"
 
 [[projects]]
   branch = "master"
+  digest = "1:dca4094c3be476189bd5854752edbd1bd3d15e61d9570dd9133744bb1ecd599d"
   name = "golang.org/x/net"
   packages = [
     "http/httpguts",
     "http2",
     "http2/hpack",
-    "idna"
+    "idna",
   ]
+  pruneopts = "UT"
   revision = "c39426892332e1bb5ec0a434a079bf82f5d30c54"
 
 [[projects]]
+  digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -96,14 +127,27 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
   ]
+  pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b7d8d94fc16de1cf511b1c4fe518392c07ab60b0a6ff5d102b5101eabbf69d9d"
+  input-imports = [
+    "github.com/alecthomas/jsonschema",
+    "github.com/bmizerany/perks/quantile",
+    "github.com/c2h5oh/datasize",
+    "github.com/dgryski/go-gk",
+    "github.com/dgryski/go-lttb",
+    "github.com/google/go-cmp/cmp",
+    "github.com/influxdata/tdigest",
+    "github.com/shurcooL/vfsgen",
+    "github.com/streadway/quantile",
+    "github.com/tsenart/go-tsz",
+    "golang.org/x/net/http2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -64,3 +64,7 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/c2h5oh/datasize"

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ footprint.
 The trade-off is one of added latency in each hit against the targets.
 
 #### `-max-body`
-Specified the maximum number of bytes to be read from the body of each
+Specifies the maximum number of bytes to be read from the body of each
 response. Set to -1 for no limit. It knows how to intepret values like these:
 
 * `"10 MB"` -> `10MB`

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ attack command:
     	Local IP address (default 0.0.0.0)
   -lazy
     	Read targets lazily
+  -max-body value
+	Maximum number of bytes to be read from response bodies. [-1 = no limit] (default -1)
   -name string
     	Attack name
   -output string
@@ -236,6 +238,22 @@ Specifies whether to read the input targets lazily instead of eagerly.
 This allows streaming targets into the attack command and reduces memory
 footprint.
 The trade-off is one of added latency in each hit against the targets.
+
+#### `-max-body`
+Specified the maximum number of bytes to be read from the body of each
+response. Set to -1 for no limit. It knows how to intepret values like these:
+
+* `"10 MB"` -> `10MB`
+* `"10240 g"` -> `10TB`
+* `"2000"` -> `2000B`
+* `"1tB"` -> `1TB`
+* `"5 peta"` -> `5PB`
+* `"28 kilobytes"` -> `28KB`
+* `"1 gigabyte"` -> `1GB`
+
+#### `-name`
+
+Specifies the name of the attack to be recorded in responses.
 
 #### `-output`
 Specifies the output file to which the binary results will be written

--- a/attack.go
+++ b/attack.go
@@ -23,6 +23,7 @@ func attackCmd() command {
 		headers: headers{http.Header{}},
 		laddr:   localAddr{&vegeta.DefaultLocalAddr},
 		rate:    vegeta.Rate{Freq: 50, Per: time.Second},
+		maxBody: vegeta.DefaultMaxBody,
 	}
 
 	fs.StringVar(&opts.name, "name", "", "Attack name")
@@ -43,6 +44,7 @@ func attackCmd() command {
 	fs.Uint64Var(&opts.workers, "workers", vegeta.DefaultWorkers, "Initial number of workers")
 	fs.IntVar(&opts.connections, "connections", vegeta.DefaultConnections, "Max open idle connections per target host")
 	fs.IntVar(&opts.redirects, "redirects", vegeta.DefaultRedirects, "Number of redirects to follow. -1 will not follow but marks as success")
+	fs.Var(&maxBodyFlag{&opts.maxBody}, "max-body", "Maximum number of bytes to be read from response bodies. [-1 = no limit]")
 	fs.Var(&rateFlag{&opts.rate}, "rate", "Number of requests per time unit")
 	fs.Var(&opts.headers, "header", "Request header")
 	fs.Var(&opts.laddr, "laddr", "Local IP address")
@@ -79,6 +81,7 @@ type attackOpts struct {
 	workers     uint64
 	connections int
 	redirects   int
+	maxBody     int64
 	headers     headers
 	laddr       localAddr
 	keepalive   bool
@@ -156,6 +159,7 @@ func attack(opts *attackOpts) (err error) {
 		vegeta.Connections(opts.connections),
 		vegeta.HTTP2(opts.http2),
 		vegeta.H2C(opts.h2c),
+		vegeta.MaxBody(opts.maxBody),
 	)
 
 	res := atk.Attack(tr, opts.rate, opts.duration, opts.name)


### PR DESCRIPTION
This change set introduces a `-max-body` flag in the attack command
as well as the corresponding `vegeta.MaxBody` functional option to
use with `vegeta.NewAttacker`.

Fixes #325