### PR TITLE
attack: Read response bodies in full

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ attack command:
   -lazy
     	Read targets lazily
   -max-body value
-    	Maximum number of bytes to be read from response bodies. [-1 = no limit] (default -1)
+    	Maximum number of bytes to capture from response bodies. [-1 = no limit] (default -1)
   -name string
     	Attack name
   -output string
@@ -120,7 +120,6 @@ examples:
   vegeta report -type=json results.bin > metrics.json
   cat results.bin | vegeta plot > plot.html
   cat results.bin | vegeta report -type="hist[0,100ms,200ms,300ms]"
-
 ```
 
 #### `-cpus`
@@ -243,8 +242,9 @@ footprint.
 The trade-off is one of added latency in each hit against the targets.
 
 #### `-max-body`
-Specifies the maximum number of bytes to be read from the body of each
-response. Set to -1 for no limit. It knows how to intepret values like these:
+Specifies the maximum number of bytes to capture from the body of each
+response. Remaining unread bytes will be fully read but discarded.
+Set to -1 for no limit. It knows how to intepret values like these:
 
 * `"10 MB"` -> `10MB`
 * `"10240 g"` -> `10TB`

--- a/attack.go
+++ b/attack.go
@@ -45,7 +45,7 @@ func attackCmd() command {
 	fs.Uint64Var(&opts.workers, "workers", vegeta.DefaultWorkers, "Initial number of workers")
 	fs.IntVar(&opts.connections, "connections", vegeta.DefaultConnections, "Max open idle connections per target host")
 	fs.IntVar(&opts.redirects, "redirects", vegeta.DefaultRedirects, "Number of redirects to follow. -1 will not follow but marks as success")
-	fs.Var(&maxBodyFlag{&opts.maxBody}, "max-body", "Maximum number of bytes to be read from response bodies. [-1 = no limit]")
+	fs.Var(&maxBodyFlag{&opts.maxBody}, "max-body", "Maximum number of bytes to capture from response bodies. [-1 = no limit]")
 	fs.Var(&rateFlag{&opts.rate}, "rate", "Number of requests per time unit")
 	fs.Var(&opts.headers, "header", "Request header")
 	fs.Var(&opts.laddr, "laddr", "Local IP address")

--- a/lib/attack.go
+++ b/lib/attack.go
@@ -69,8 +69,8 @@ func NewAttacker(opts ...func(*Attacker)) *Attacker {
 
 	a.client = http.Client{
 		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			Dial:  a.dialer.Dial,
+			Proxy:                 http.ProxyFromEnvironment,
+			Dial:                  a.dialer.Dial,
 			ResponseHeaderTimeout: DefaultTimeout,
 			TLSClientConfig:       DefaultTLSConfig,
 			TLSHandshakeTimeout:   10 * time.Second,
@@ -318,6 +318,8 @@ func (a *Attacker) hit(tr Targeter, name string) *Result {
 	}
 
 	if res.Body, err = ioutil.ReadAll(body); err != nil {
+		return &res
+	} else if _, err = io.Copy(ioutil.Discard, r.Body); err != nil {
 		return &res
 	}
 


### PR DESCRIPTION
PR #326 introduced a way to limit the number of bytes read from HTTP responses.
However, as pointed out by @smartyjohn in #302 (comment), it didn't solve the need
of reading all the response bodies (in order to observe the full network latency timing)
but discard them at the end.

This was an oversight and unintentional, so this change set changes the semantics
of both the `-max-body` flag in the `attack` command and the correspondent
`vegeta.MaxBody` `Attacker` option.

Instead of limiting the number of bytes **read** from the response bodies,
it limits the number of bytes **captured** from response bodies while
always reading the full body from the underlying connection.

Fixes #339