### PR TITLE
Add support for building snaps

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,21 @@
+name: vegeta
+version: '1.0'
+summary: HTTP load testing tool and library 
+description: |
+  HTTP load testing tool and library. It's over 9000!
+grade: stable
+confinement: strict
+base: core18
+parts:
+  vegeta:
+    plugin: go
+    source: https://github.com/tsenart/vegeta.git
+    go-importpath: github.com/tsenart/vegeta
+    build-packages:
+      - build-essential
+apps:
+  vegeta:
+    command: bin/vegeta
+    plugs:
+      - home
+      - network


### PR DESCRIPTION
Tomas, I read your guidelines, so hopefully this PR will meet them.

I would like to ask you to add snap support for vegeta.

Snaps are cross-distro software package, with automatic updates. You can make the app once, publish it as snap and not worry about any distro-specific compatibility - this is handled by the snap service on any supported distro - and this is a big family with Ubuntu, Debian, Fedora, SUSE, Manjaro, and many others.

So this might be a nice opportunity, especially if you're looking to simplify deployment and reach a wider audience.

On the technical side, I'd like to outline what I did, so if you want to accept this PR, you can do the same and land your snap in the Snap Store (snapcraft.io/store).

1. Snaps are built using snapcraft, a command line tool.
2. You can build on various systems, but the simplest and eaiser is to use Ubuntu 18.10 LTS.
3. The process includes getting snapcraft, building with snapcraft using a snapcraft.yaml file, and finally publishing in the store.

**Install and run snapcraft**

snap install snapcraft --classic --beta
git clone https://github.com/igorljubuncic/vegeta.git
cd vegeta
git checkout add-snapcraft
snapcraft

This command will generate a <vegeta-version>.snap file, something like vegeta_1.0_amd64.snap.

**Test on your system**

This snap can be installed and tested locally with:

snap install vegeta_1.0_amd64.snap --dangerous

You need the --dangerous flag because the snap isn't in the store and yet and has no digital signature.

**Run snap and test behavior**

snap run vegeta

**Register developer account**

Create an account: https://snapcraft.io/account.

**Login & register on the command line**

snapcraft login
snapcraft register

**Upload snap to the store**

This is done by pushing the created snap to the store, and you need to choose a channel. We have multiple channels, i.e. risk levels, similar to the traditional deployment phases (alpha, beta, etc.).

We use a slightly different categorization, with 'edge' for the riskiest, and this is always the best channel to choose when uploading a new snap or new, untested version. You can then promote to 'beta' and 'candidate' and finally to 'stable' once you're happy with how your snap is working.

snapcraft push vegeta_1.0_amd64.snap --release edge

**Test on a clean machine**

This will install from the store - previously, we tested a local install:

snap install vegeta --edge

I hope this covers all the steps, and this is clear and simple. If not, you can always reach out and I can help with the details. It would be really nice to have your app (and not just because of the cool avatar) in the Snap Store. Have a good one.