### PR TITLE
docs(cpus): correct default of CPUs usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Usage: vegeta [global flags] <command> [command flags]
 
 global flags:
   -cpus int
-    	Number of CPUs to use (default 8)
+    	Number of CPUs to use (defaults to the number of CPUs you have)
   -profile string
     	Enable profiling of [cpu, heap]
   -version


### PR DESCRIPTION
#### Background

<!-- Required background information to understand the PR. Link here any related issues. -->

In the Readme is stated that the number of CPUs used defaults to 8 which isn't correct, see: https://github.com/tsenart/vegeta/blob/0cabfc957a3db953c27ffaccff3ac2327a0dbcde/main.go#L24

BTW: is the commit message okay or how should I name it?

#### Checklist

- [ ] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] Each Git commit represents meaningful milestones or atomic units of work.
- [ ] Changed or added code is covered by appropriate tests.
