### PR TITLE
Create Rater interface to allow for attack rates to vary on the fly.

### DIFF
--- a/lib/attack.go
+++ b/lib/attack.go
@@ -72,8 +72,8 @@ func NewAttacker(opts ...func(*Attacker)) *Attacker {
 
 	a.client = http.Client{
 		Transport: &http.Transport{
-			Proxy:                 http.ProxyFromEnvironment,
-			Dial:                  a.dialer.Dial,
+			Proxy: http.ProxyFromEnvironment,
+			Dial:  a.dialer.Dial,
 			ResponseHeaderTimeout: DefaultTimeout,
 			TLSClientConfig:       DefaultTLSConfig,
 			TLSHandshakeTimeout:   10 * time.Second,
@@ -223,7 +223,19 @@ func Client(c *http.Client) func(*Attacker) {
 	return func(a *Attacker) { a.client = *c }
 }
 
-// A Rate of hits during an Attack.
+// Rater defines the rate of hits during an Attack.
+type Rater interface {
+	// Interval returns the time the attacker needs to sleep
+	// before the next hit is sent to the target.
+	Interval(began time.Time, count uint64) time.Duration
+	// Hits takes the desired attack duration and returns the
+	// number of hits sent in that duration while attacking.
+	Hits(attackDuration time.Duration) uint64
+	// IsZero returns true if the rater is zero-valued.
+	IsZero() bool
+}
+
+// Rate sends a constant rate of hits to the target.
 type Rate struct {
 	Freq int           // Frequency (number of occurrences) per ...
 	Per  time.Duration // Time unit, usually 1s
@@ -234,11 +246,40 @@ func (r Rate) IsZero() bool {
 	return r.Freq == 0 || r.Per == 0
 }
 
+// Interval implements part of the Rater interface. It calculates the time
+// between each hit from r.Per / r.Freq and multiplies this by the count of
+// hits already elapsed to determine the absolute time when the next hit should
+// occur. It returns the Duration until that time.
+func (r Rate) Interval(began time.Time, count uint64) time.Duration {
+	return r.interval(began, time.Now(), count)
+}
+
+func (r Rate) interval(began, now time.Time, count uint64) time.Duration {
+	delta := time.Duration(count * uint64(r.Per.Nanoseconds()/int64(r.Freq)))
+	return began.Add(delta).Sub(now)
+}
+
+// Hits implements part of the Rater interface. It returns the number of hits
+// the attacker is expected to send when applying this Rate over the provided
+// Duration.
+func (r Rate) Hits(du time.Duration) uint64 {
+	if du == 0 || r.IsZero() {
+		return 0
+	}
+	return uint64(du) / (uint64(r.Per.Nanoseconds() / int64(r.Freq)))
+}
+
+// String returns a pretty-printed description of the rate, e.g.:
+//   Rate{1 hits/1s} for Rate{Freq:1, Per: time.Second}
+func (r Rate) String() string {
+	return fmt.Sprintf("Rate{%d hits/%s}", r.Freq, r.Per)
+}
+
 // Attack reads its Targets from the passed Targeter and attacks them at
 // the rate specified for the given duration. When the duration is zero the attack
 // runs until Stop is called. Results are sent to the returned channel as soon
 // as they arrive and will have their Attack field set to the given name.
-func (a *Attacker) Attack(tr Targeter, r Rate, du time.Duration, name string) <-chan *Result {
+func (a *Attacker) Attack(tr Targeter, r Rater, du time.Duration, name string) <-chan *Result {
 	var workers sync.WaitGroup
 	results := make(chan *Result)
 	ticks := make(chan uint64)
@@ -251,12 +292,10 @@ func (a *Attacker) Attack(tr Targeter, r Rate, du time.Duration, name string) <-
 		defer close(results)
 		defer workers.Wait()
 		defer close(ticks)
-		interval := uint64(r.Per.Nanoseconds() / int64(r.Freq))
-		hits := uint64(du) / interval
+		hits := r.Hits(du)
 		began, count := time.Now(), uint64(0)
 		for {
-			now, next := time.Now(), began.Add(time.Duration(count*interval))
-			time.Sleep(next.Sub(now))
+			time.Sleep(r.Interval(began, count))
 			select {
 			case ticks <- count:
 				if count++; count == hits {

--- a/lib/attack_test.go
+++ b/lib/attack_test.go
@@ -356,3 +356,58 @@ func TestClient(t *testing.T) {
 		t.Errorf("Expected timeout error")
 	}
 }
+
+func TestRateInterval(t *testing.T) {
+	t.Parallel()
+	began := time.Now()
+
+	for i, tt := range []struct {
+		freq  int
+		per   time.Duration
+		count uint64
+		since time.Duration
+		want  time.Duration
+	}{
+		// 1 hit/sec, 0 hits sent, 1s elapsed => -1s until next hit
+		// (time.Sleep will return immediately in this case)
+		{1, time.Second, 0, time.Second, -time.Second},
+		// 1 hit/sec, 1 hit sent, 1s elapsed => 0s until next hit
+		{1, time.Second, 1, time.Second, 0},
+		// 1 hit/sec, 2 hits sent, 1s elapsed => 1s until next hit
+		{1, time.Second, 2, time.Second, time.Second},
+		// 1 hit/sec, 10 hits sent, 1s elapsed => 9s until next hit
+		{1, time.Second, 10, time.Second, 9 * time.Second},
+		// 1 hit/sec, 10 hits sent, 10s elapsed => 0s until next hit
+		{1, time.Second, 10, 10 * time.Second, 0},
+		// 2 hit/sec, 9 hits sent, 4.4s elapsed => 100ms until next hit
+		{2, time.Second, 9, (44 * time.Second) / 10, 100 * time.Millisecond},
+	} {
+		r := Rate{Freq: tt.freq, Per: tt.per}
+		got := r.interval(began, began.Add(tt.since), tt.count)
+		if got != tt.want {
+			t.Errorf("%d: %v.Interval(%v, %d) = %v; want %v",
+				i, r, tt.since, tt.count, got, tt.want)
+		}
+	}
+}
+
+func TestRateHits(t *testing.T) {
+	for i, tt := range []struct {
+		freq int
+		per  time.Duration
+		du   time.Duration
+		want uint64
+	}{
+		{1, time.Second, 0, 0},
+		{1, time.Second, time.Second, 1},
+		{2, time.Second, time.Second, 2},
+		{1, time.Second, 10 * time.Second, 10},
+		{100, time.Second, 100 * time.Second, 100 * 100},
+	} {
+		r := Rate{Freq: tt.freq, Per: tt.per}
+		got := r.Hits(tt.du)
+		if got != tt.want {
+			t.Errorf("%d: %v.Hits(%v) = %d; want %d", i, r, tt.du, got, tt.want)
+		}
+	}
+}

--- a/lib/rater.go
+++ b/lib/rater.go
@@ -1,0 +1,186 @@
+package vegeta
+
+import (
+	"fmt"
+	"math"
+	"time"
+)
+
+const (
+	MeanUp   float64 = 0
+	Peak             = math.Pi / 2
+	MeanDown         = math.Pi
+	Trough           = 3 * math.Pi / 2
+)
+
+// Rater defines the rate of hits during an Attack.
+type Rater interface {
+	// Interval returns the time the attacker needs to sleep
+	// before the next hit is sent to the target.
+	Interval(began time.Time, count uint64) time.Duration
+	// Hits takes the desired attack duration and returns the
+	// number of hits sent in that duration while attacking.
+	Hits(attackDuration time.Duration) uint64
+	// IsZero returns true if the rater is zero-valued.
+	IsZero() bool
+}
+
+// Rate sends a constant rate of hits to the target.
+type Rate struct {
+	Freq int           // Frequency (number of occurrences) per ...
+	Per  time.Duration // Time unit, usually 1s
+}
+
+var _ Rater = Rate{}
+
+// IsZero returns true if either Freq or Per are zero valued.
+func (r Rate) IsZero() bool {
+	return r.Freq == 0 || r.Per == 0
+}
+
+// Interval implements part of the Rater interface. It calculates the time
+// between each hit from r.Per / r.Freq and multiplies this by the count of
+// hits already elapsed to determine the absolute time when the next hit should
+// occur. It returns the Duration until that time.
+func (r Rate) Interval(began time.Time, count uint64) time.Duration {
+	return r.interval(began, time.Now(), count)
+}
+
+func (r Rate) interval(began, now time.Time, count uint64) time.Duration {
+	delta := time.Duration(count * uint64(r.Per.Nanoseconds()/int64(r.Freq)))
+	return began.Add(delta).Sub(now)
+}
+
+// Hits implements part of the Rater interface. It returns the number of hits
+// the attacker is expected to send when applying this Rate over the provided
+// Duration.
+func (r Rate) Hits(du time.Duration) uint64 {
+	if du == 0 || r.IsZero() {
+		return 0
+	}
+	return uint64(du) / (uint64(r.Per.Nanoseconds() / int64(r.Freq)))
+}
+
+// String returns a pretty-printed description of the rate, e.g.:
+//   Rate{1 hits/1s} for Rate{Freq:1, Per: time.Second}
+func (r Rate) String() string {
+	return fmt.Sprintf("Rate{%d hits/%s}", r.Freq, r.Per)
+}
+
+// SineRate is a Rater that describes attack request rates
+// with the equation:
+//     R = MA sin(O+(2𝛑/P)t)
+// Where:
+//   R = Instantaneous attack rate at elapsed time t, hits per nanosecond
+//   M = Mean attack rate over period P, sr.Mean, hits per nanosecond
+//   A = Amplitude of sine wave, sr.Amp, hits per nanosecond
+//   O = Offset of sine wave, sr.StartAt, radians
+//   P = Period of sine wave, sr.Period, nanoseconds
+//   t = Elapsed time since attack, nanoseconds
+// The attack rate (sr.HitsPerNs) is described by the equation:
+//
+// This equation is integrated with respect to time to derive the expected
+// number of hits served at time t after the attack began:
+//     H = Mt - (AP/2𝛑)cos(O+(2𝛑/P)t) + (AP/2𝛑)cos(O)
+// Where:
+//   H = Total number of hits triggered during t
+type SineRate struct {
+	// The period of the sine wave, e.g. 20*time.Minute
+	// MUST BE > 0
+	Period time.Duration
+	// The mid-point of the sine wave in freq-per-Duration,
+	// e.g. 100/float64(time.Second) for 100 QPS
+	// MUST BE > 0
+	Mean float64
+	// The amplitude of the sine wave in freq-per-Duration,
+	// e.g. 90/float64(time.Second) for ±90 QPS
+	// MUST NOT BE EQUAL TO OR LARGER THAN MEAN
+	Amp float64
+	// The offset, in radians, for the sine wave at t=0.
+	StartAt float64
+}
+
+var _ Rater = SineRate{}
+
+// IsZero is more of an IsInvalid but whatever :-)
+func (sr SineRate) IsZero() bool {
+	if sr.Period <= 0 || sr.Mean <= 0 || sr.Amp >= sr.Mean {
+		return true
+	}
+	return false
+}
+
+// Interval returns the Duration until the next hit should be sent,
+// based on when the attack began and how many hits have been sent thus far.
+func (sr SineRate) Interval(began time.Time, count uint64) time.Duration {
+	return sr.interval(time.Since(began), count)
+}
+
+// Interval returns the Duration until the next hit should be sent,
+// based on when the attack began and how many hits have been sent thus far.
+func (sr SineRate) interval(elapsedTime time.Duration, count uint64) time.Duration {
+	expectedHits := sr.hits(elapsedTime)
+	if count < uint64(expectedHits) {
+		// Running behind, send next hit immediately.
+		return 0
+	}
+	// Re-arranging our hits equation to provide a duration given the number of
+	// requests sent is non-trivial, so we must solve for the duration numerically.
+	// math.Round() added here because we have to coerce to int64 nanoseconds
+	// at some point and it corrects a bunch of off-by-one problems.
+	nsPerHit := math.Round(1 / sr.HitsPerNs(elapsedTime))
+	hitsToWait := float64(count+1) - expectedHits
+	nextHitIn := time.Duration(nsPerHit * hitsToWait)
+
+	// If we can't converge to an error of <1e-3 within 5 iterations, bail.
+	// This rarely even loops for any large Period if hitsToWait is small.
+	for i := 0; i < 5; i++ {
+		hitsAtGuess := sr.hits(elapsedTime + nextHitIn)
+		err := float64(count+1) - hitsAtGuess
+		if math.Abs(err) < 1e-3 {
+			return nextHitIn
+		}
+		nextHitIn = time.Duration(float64(nextHitIn) / (hitsAtGuess - float64(count)))
+	}
+	return nextHitIn
+}
+
+// AmpHits returns AP/2𝛑, which is the number of hits added or subtracted
+// from the Mean due to the Amplitude over a quarter of the Period,
+// i.e. from 0 → 𝛑/2 radians
+func (sr SineRate) AmpHits() float64 {
+	return (sr.Amp * float64(sr.Period)) / (2 * math.Pi)
+}
+
+// radians converts the elapsed attack time to a radian value.
+// The elapsed time t is divided by the wave period, multiplied by 2𝛑 to
+// convert to radians, and offset by StartAt radians.
+func (sr SineRate) Radians(t time.Duration) float64 {
+	return sr.StartAt + float64(t)*2*math.Pi/float64(sr.Period)
+}
+
+// HitsPerNs calculates the instantaneous rate of attack at
+// t nanoseconds after the attack began.
+//     R = MA sin(O+(2𝛑/P)t)
+func (sr SineRate) HitsPerNs(t time.Duration) float64 {
+	return sr.Mean + sr.Amp*math.Sin(sr.Radians(t))
+}
+
+// hits is an internal version of Hits that returns a float64, so we can tell
+// exactly how much we've missed our target by when solving numerically.
+//     H = Mt - (AP/2𝛑)cos(O+(2𝛑/P)t) + (AP/2𝛑)cos(O)
+// This re-arranges to:
+//     H = Mt + (AP/2𝛑)(cos(O) - cos(O+(2𝛑/P)t))
+func (sr SineRate) hits(t time.Duration) float64 {
+	return sr.Mean*float64(t) + sr.AmpHits()*(math.Cos(sr.StartAt)-math.Cos(sr.Radians(t)))
+}
+
+// Hits returns the number of requests that have been sent during an attack
+// lasting t nanoseconds.
+//     H = Mt - (AP/2𝛑)cos(O+(2𝛑/P)t) + (AP/2𝛑)cos(O)
+func (sr SineRate) Hits(t time.Duration) uint64 {
+	if t == 0 || sr.IsZero() {
+		return 0
+	}
+	return uint64(math.Round(sr.hits(t)))
+}

--- a/lib/rater_test.go
+++ b/lib/rater_test.go
@@ -1,0 +1,159 @@
+package vegeta
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+var quarterPeriods = map[string]float64{
+	"MeanUp":   MeanUp,
+	"Peak":     Peak,
+	"MeanDown": MeanDown,
+	"Trough":   Trough,
+}
+
+func TestRateInterval(t *testing.T) {
+	t.Parallel()
+	began := time.Now()
+
+	for i, tt := range []struct {
+		freq  int
+		per   time.Duration
+		count uint64
+		since time.Duration
+		want  time.Duration
+	}{
+		// 1 hit/sec, 0 hits sent, 1s elapsed => -1s until next hit
+		// (time.Sleep will return immediately in this case)
+		{1, time.Second, 0, time.Second, -time.Second},
+		// 1 hit/sec, 1 hit sent, 1s elapsed => 0s until next hit
+		{1, time.Second, 1, time.Second, 0},
+		// 1 hit/sec, 2 hits sent, 1s elapsed => 1s until next hit
+		{1, time.Second, 2, time.Second, time.Second},
+		// 1 hit/sec, 10 hits sent, 1s elapsed => 9s until next hit
+		{1, time.Second, 10, time.Second, 9 * time.Second},
+		// 1 hit/sec, 10 hits sent, 10s elapsed => 0s until next hit
+		{1, time.Second, 10, 10 * time.Second, 0},
+		// 2 hit/sec, 9 hits sent, 4.4s elapsed => 100ms until next hit
+		{2, time.Second, 9, (44 * time.Second) / 10, 100 * time.Millisecond},
+	} {
+		r := Rate{Freq: tt.freq, Per: tt.per}
+		got := r.interval(began, began.Add(tt.since), tt.count)
+		if got != tt.want {
+			t.Errorf("%d: %v.Interval(%v, %d) = %v; want %v",
+				i, r, tt.since, tt.count, got, tt.want)
+		}
+	}
+}
+
+func TestRateHits(t *testing.T) {
+	for i, tt := range []struct {
+		freq int
+		per  time.Duration
+		du   time.Duration
+		want uint64
+	}{
+		{1, time.Second, 0, 0},
+		{1, time.Second, time.Second, 1},
+		{2, time.Second, time.Second, 2},
+		{1, time.Second, 10 * time.Second, 10},
+		{100, time.Second, 100 * time.Second, 100 * 100},
+	} {
+		r := Rate{Freq: tt.freq, Per: tt.per}
+		got := r.Hits(tt.du)
+		if got != tt.want {
+			t.Errorf("%d: %v.Hits(%v) = %d; want %d", i, r, tt.du, got, tt.want)
+		}
+	}
+}
+
+type sineTest struct {
+	p, m, a float64
+}
+
+func (st sineTest) Rate(startAt float64) SineRate {
+	return SineRate{
+		Period:  time.Duration(st.p) * time.Second,
+		Mean:    st.m / float64(time.Second),
+		Amp:     st.a / float64(time.Second),
+		StartAt: startAt,
+	}
+}
+
+func (st sineTest) AmpHits() float64 {
+	return (st.a * st.p) / (2 * math.Pi)
+}
+
+func (st sineTest) Hits(frac, startAt float64) uint64 {
+	return uint64(math.Round(
+		st.m*st.p*frac +
+			st.AmpHits()*(math.Cos(startAt)-math.Cos(startAt+frac*2*math.Pi))))
+}
+
+func (st sineTest) Nanos(frac, startAt float64) time.Duration {
+	return time.Duration(1 / (st.m + st.a*math.Sin(startAt+frac*2*math.Pi)))
+}
+
+func TestSineRateHits(t *testing.T) {
+	tests := []sineTest{
+		{20 * 60, 100, 90},
+		{60, 1000, 10},
+		{1, 1, 0.7},
+		{1, 1, 0},
+		// These test cases failed with off-by-one errors before applying
+		// math.Round in Hits, due to floating-point maths differences.
+		{1e6, 1, 0.7},
+		{60, 1000, 999},
+	}
+
+	for i, test := range tests {
+		for name, sa := range quarterPeriods {
+			sr := test.Rate(sa)
+			if got, want := sr.Hits(sr.Period/4), test.Hits(0.25, sa); got != want {
+				t.Errorf("%d(%s): hits after 1/4 period = %d, want %d", i, name, got, want)
+			}
+			if got, want := sr.Hits(sr.Period/2), test.Hits(0.5, sa); got != want {
+				t.Errorf("%d(%s): hits after 1/2 period = %d, want %d", i, name, got, want)
+			}
+			if got, want := sr.Hits(3*sr.Period/4), test.Hits(0.75, sa); got != want {
+				t.Errorf("%d(%s): hits after 3/4 period = %d, want %d", i, name, got, want)
+			}
+			if got, want := sr.Hits(sr.Period), test.Hits(1, sa); got != want {
+				t.Errorf("%d(%s): hits after full period = %d, want %d", i, name, got, want)
+			}
+		}
+	}
+}
+
+func TestSineIntervalFlat(t *testing.T) {
+	st := sineTest{1, 1, 0}
+	tests := []struct {
+		et   time.Duration
+		c    uint64
+		want time.Duration
+	}{
+		{0, 0, time.Second},
+		{0, 1, 2 * time.Second},
+		{time.Second / 100, 0, 99 * time.Second / 100},
+		{time.Second / 2, 0, time.Second / 2},
+		{64 * time.Second / 100, 0, 36 * time.Second / 100},
+		// Has an off-by-one I can't round away nicely because it's
+		// due to expectedHits being 0.9900000000000001. Ugh floats.
+		// {99 * time.Second / 100, 0, time.Second / 100},
+		{time.Second, 1, time.Second},
+		{time.Second, 0, 0},
+	}
+
+	for i, test := range tests {
+		for name, sa := range quarterPeriods {
+			sr := st.Rate(sa)
+			if got := sr.interval(test.et, test.c); got != test.want {
+				t.Errorf("%d(%s): interval(%v, %d) = %v, want %v",
+					i, name, test.et, test.c, got, test.want)
+			}
+		}
+	}
+}
+
+// No idea how to test interval without hard-coding a bunch of numbers.


### PR DESCRIPTION
Hi there!

#### Background

I wanted to be able to vary attack rates over time, for Reasons. The easiest way of doing so seems to be to create an interface that can provide the information Attack needs, namely the total number of hits in the provided Duration, and the interval to sleep before the next hit. The change is primarily structured so that code using the vegeta lib will continue to function as before. I'm not wedded to the "Rater" interface name.

If you'd like to know more about *why* I want this, please let me know.

#### Checklist

- [✗] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).

Hrrrm, I might have to amend and re-push this branch to meet this requirement, I'll do that after I'm finished typing here.

- [✓] Each Git commit represents meaningful milestones or atomic units of work.

- [✓] Changed or added code is covered by appropriate tests.

All tests of attack behaviour still pass. If you'd like me to add specific unit tests for Hits / Interval, please let me know.