### PR TITLE
Use response content length to calculate bytes in

### DIFF
--- a/lib/attack.go
+++ b/lib/attack.go
@@ -328,6 +328,10 @@ func (a *Attacker) hit(tr Targeter, name string) *Result {
 	res.Latency = time.Since(res.Timestamp)
 	res.BytesIn = uint64(len(res.Body))
 
+	if r.ContentLength != -1 {
+		res.BytesIn = uint64(r.ContentLength)
+	}
+
 	if req.ContentLength != -1 {
 		res.BytesOut = uint64(req.ContentLength)
 	}


### PR DESCRIPTION
#### Background
Closes issue #383
If available use content length as the number of bytes otherwise fallback to length of body.