### PR TITLE
Add unix sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,12 @@ attack command:
     	Targets file (default "stdin")
   -timeout duration
     	Requests timeout (default 30s)
+  -unix-socket string
+    	Connect over a unix socket. This overrides the host address in target URLs
   -workers uint
     	Initial number of workers (default 10)
+
+
 
 encode command:
   -output string

--- a/attack.go
+++ b/attack.go
@@ -50,6 +50,7 @@ func attackCmd() command {
 	fs.Var(&opts.headers, "header", "Request header")
 	fs.Var(&opts.laddr, "laddr", "Local IP address")
 	fs.BoolVar(&opts.keepalive, "keepalive", true, "Use persistent connections")
+	fs.StringVar(&opts.unixSocket, "unix-socket", "", "Connect over a unix socket. This overrides the host address in target URLs")
 	systemSpecificFlags(fs, opts)
 
 	return command{fs, func(args []string) error {
@@ -88,6 +89,7 @@ type attackOpts struct {
 	laddr       localAddr
 	keepalive   bool
 	resolvers   csl
+	unixSocket  string
 }
 
 // attack validates the attack arguments, sets up the
@@ -171,6 +173,7 @@ func attack(opts *attackOpts) (err error) {
 		vegeta.HTTP2(opts.http2),
 		vegeta.H2C(opts.h2c),
 		vegeta.MaxBody(opts.maxBody),
+		vegeta.UnixSocket(opts.unixSocket),
 	)
 
 	res := atk.Attack(tr, opts.rate, opts.duration, opts.name)

--- a/lib/attack.go
+++ b/lib/attack.go
@@ -1,6 +1,7 @@
 package vegeta
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -204,6 +205,17 @@ func H2C(enabled bool) func(*Attacker) {
 // read from response bodies. Set to -1 to disable any limits.
 func MaxBody(n int64) func(*Attacker) {
 	return func(a *Attacker) { a.maxBody = n }
+}
+
+// UnixSocket changes the dialer for the attacker to use the specified unix socket file
+func UnixSocket(socket string) func(*Attacker) {
+	return func(a *Attacker) {
+		if tr, ok := a.client.Transport.(*http.Transport); socket != "" && ok {
+			tr.DialContext = func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", socket)
+			}
+		}
+	}
 }
 
 // Client returns a functional option that allows you to bring your own http.Client

--- a/lib/attack_test.go
+++ b/lib/attack_test.go
@@ -5,10 +5,13 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -267,6 +270,61 @@ func TestMaxBody(t *testing.T) {
 	}
 }
 
+func TestUnixSocket(t *testing.T) {
+	t.Parallel()
+	body := []byte("IT'S A UNIX SYSTEM, I KNOW THIS")
+
+	socketDir, err := ioutil.TempDir("", "vegata")
+	if err != nil {
+		t.Error("Failed to create socket dir", err)
+		return
+	}
+	defer os.RemoveAll(socketDir)
+	socketFile := filepath.Join(socketDir, "test.sock")
+
+	unixListener, err := net.Listen("unix", socketFile)
+
+	if err != nil {
+		t.Error("Failed to listen on unix socket", err)
+		return
+	}
+
+	server := http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write(body)
+		}),
+	}
+	defer server.Close()
+
+	go server.Serve(unixListener)
+
+	start := time.Now()
+	for {
+		if time.Since(start) > 1*time.Second {
+			t.Error("Server didn't listen on unix socket in time")
+			return
+		}
+		_, err := os.Stat(socketFile)
+		if err == nil {
+			break
+		} else if os.IsNotExist(err) {
+			time.Sleep(10 * time.Millisecond)
+		} else {
+			t.Error("unexpected error from unix socket", err)
+			return
+		}
+	}
+
+	atk := NewAttacker(UnixSocket(socketFile))
+
+	tr := NewStaticTargeter(Target{Method: "GET", URL: "http://anyserver/"})
+	res := atk.hit(tr, "")
+	if !bytes.Equal(res.Body, body) {
+		t.Errorf("got: %s, want: %s", string(res.Body), string(body))
+		return
+	}
+}
+
 func TestClient(t *testing.T) {
 	t.Parallel()
 
@@ -279,8 +337,8 @@ func TestClient(t *testing.T) {
 	client := &http.Client{
 		Timeout: time.Duration(1 * time.Nanosecond),
 		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			Dial:  dialer.Dial,
+			Proxy:                 http.ProxyFromEnvironment,
+			Dial:                  dialer.Dial,
 			ResponseHeaderTimeout: DefaultTimeout,
 			TLSClientConfig:       DefaultTLSConfig,
 			TLSHandshakeTimeout:   10 * time.Second,


### PR DESCRIPTION
#### Background
We use a few HTTP services that are exposed over a unix socket rather than TCP, Go's support for this is good  and is used in several projects (e.g. Docker)  and would like to use vegeta for load testing them. 

This commit adds a `--unix-socket /path/to/unix.sock` option that sets the dialler on the request to a dialler for that unix socket. 

#### Checklist

- [X ] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [X ] Each Git commit represents meaningful milestones or atomic units of work.
- [X ] Changed or added code is covered by appropriate tests.
