### PR TITLE
Introduce Rater interface and FixedRater

### DIFF
--- a/attack.go
+++ b/attack.go
@@ -173,7 +173,8 @@ func attack(opts *attackOpts) (err error) {
 		vegeta.MaxBody(opts.maxBody),
 	)
 
-	res := atk.Attack(tr, opts.rate, opts.duration, opts.name)
+	rater := vegeta.NewFixedRater(opts.rate, opts.duration)
+	res := atk.Attack(tr, rater, opts.name)
 	enc := vegeta.NewEncoder(out)
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, os.Interrupt)

--- a/lib/attack.go
+++ b/lib/attack.go
@@ -71,8 +71,8 @@ func NewAttacker(opts ...func(*Attacker)) *Attacker {
 
 	a.client = http.Client{
 		Transport: &http.Transport{
-			Proxy:                 http.ProxyFromEnvironment,
-			Dial:                  a.dialer.Dial,
+			Proxy: http.ProxyFromEnvironment,
+			Dial:  a.dialer.Dial,
 			ResponseHeaderTimeout: DefaultTimeout,
 			TLSClientConfig:       DefaultTLSConfig,
 			TLSHandshakeTimeout:   10 * time.Second,
@@ -211,7 +211,19 @@ func Client(c *http.Client) func(*Attacker) {
 	return func(a *Attacker) { a.client = *c }
 }
 
-// A Rate of hits during an Attack.
+// Rater defines the rate of hits during an Attack.
+type Rater interface {
+	// Interval returns the time the attacker needs to sleep
+	// before the next hit is sent to the target.
+	Interval(began time.Time, count uint64) time.Duration
+	// Hits takes the desired attack duration and returns the
+	// number of hits sent in that duration while attacking.
+	Hits(attackDuration time.Duration) uint64
+	// IsZero returns true if the rater is zero-valued.
+	IsZero() bool
+}
+
+// Rate sends a constant rate of hits to the target.
 type Rate struct {
 	Freq int           // Frequency (number of occurrences) per ...
 	Per  time.Duration // Time unit, usually 1s
@@ -222,11 +234,40 @@ func (r Rate) IsZero() bool {
 	return r.Freq == 0 || r.Per == 0
 }
 
+// Interval implements part of the Rater interface. It calculates the time
+// between each hit from r.Per / r.Freq and multiplies this by the count of
+// hits already elapsed to determine the absolute time when the next hit should
+// occur. It returns the Duration until that time.
+func (r Rate) Interval(began time.Time, count uint64) time.Duration {
+	return r.interval(began, time.Now(), count)
+}
+
+func (r Rate) interval(began, now time.Time, count uint64) time.Duration {
+	delta := time.Duration(count * uint64(r.Per.Nanoseconds()/int64(r.Freq)))
+	return began.Add(delta).Sub(now)
+}
+
+// Hits implements part of the Rater interface. It returns the number of hits
+// the attacker is expected to send when applying this Rate over the provided
+// Duration.
+func (r Rate) Hits(du time.Duration) uint64 {
+	if du == 0 || r.IsZero() {
+		return 0
+	}
+	return uint64(du) / (uint64(r.Per.Nanoseconds() / int64(r.Freq)))
+}
+
+// String returns a pretty-printed description of the rate, e.g.:
+//   Rate{1 hits/1s} for Rate{Freq:1, Per: time.Second}
+func (r Rate) String() string {
+	return fmt.Sprintf("Rate{%d hits/%s}", r.Freq, r.Per)
+}
+
 // Attack reads its Targets from the passed Targeter and attacks them at
 // the rate specified for the given duration. When the duration is zero the attack
 // runs until Stop is called. Results are sent to the returned channel as soon
 // as they arrive and will have their Attack field set to the given name.
-func (a *Attacker) Attack(tr Targeter, r Rate, du time.Duration, name string) <-chan *Result {
+func (a *Attacker) Attack(tr Targeter, r Rater, du time.Duration, name string) <-chan *Result {
 	var workers sync.WaitGroup
 	results := make(chan *Result)
 	ticks := make(chan uint64)
@@ -239,12 +280,10 @@ func (a *Attacker) Attack(tr Targeter, r Rate, du time.Duration, name string) <-
 		defer close(results)
 		defer workers.Wait()
 		defer close(ticks)
-		interval := uint64(r.Per.Nanoseconds() / int64(r.Freq))
-		hits := uint64(du) / interval
+		hits := r.Hits(du)
 		began, count := time.Now(), uint64(0)
 		for {
-			now, next := time.Now(), began.Add(time.Duration(count*interval))
-			time.Sleep(next.Sub(now))
+			time.Sleep(r.Interval(began, count))
 			select {
 			case ticks <- count:
 				if count++; count == hits {

--- a/lib/attack.go
+++ b/lib/attack.go
@@ -71,8 +71,8 @@ func NewAttacker(opts ...func(*Attacker)) *Attacker {
 
 	a.client = http.Client{
 		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			Dial:  a.dialer.Dial,
+			Proxy:                 http.ProxyFromEnvironment,
+			Dial:                  a.dialer.Dial,
 			ResponseHeaderTimeout: DefaultTimeout,
 			TLSClientConfig:       DefaultTLSConfig,
 			TLSHandshakeTimeout:   10 * time.Second,
@@ -211,16 +211,58 @@ func Client(c *http.Client) func(*Attacker) {
 	return func(a *Attacker) { a.client = *c }
 }
 
-// Rater defines the rate of hits during an Attack.
+// A Rater defines the rate of hits during an Attack by
+// returning the duration an Attacker should wait until hiting
+// the next Target. When a negative value time is returned,
+// an Attacker will stop.
 type Rater interface {
-	// Interval returns the time the attacker needs to sleep
-	// before the next hit is sent to the target.
-	Interval(began time.Time, count uint64) time.Duration
-	// Hits takes the desired attack duration and returns the
-	// number of hits sent in that duration while attacking.
-	Hits(attackDuration time.Duration) uint64
-	// IsZero returns true if the rater is zero-valued.
-	IsZero() bool
+	Wait(began, now time.Time) time.Duration
+}
+
+// A RaterFunc is a function adapter type that implements the
+// Rater interface.
+type RaterFunc func(began, now time.Time) time.Duration
+
+// Wait implements the Rater interface.
+func (f RaterFunc) Wait(began, now time.Time) time.Duration {
+	return f(began, now)
+}
+
+// A FixedRater is a Rater that produces hits at a fixed rate
+// for a given duration. It is not safe for concurrent use.
+type FixedRater struct {
+	rate  Rate
+	hits  uint64
+	count uint64
+}
+
+// NewFixedRater returns a new FixedRater with the given Rate and duration.
+// When duration is zero, the rater will never stop.
+func NewFixedRater(rate Rate, du time.Duration) *FixedRater {
+	r := FixedRater{rate: rate}
+	if du != 0 && !rate.IsZero() {
+		r.hits = uint64(du) /
+			(uint64(rate.Per.Nanoseconds() / int64(rate.Freq)))
+	}
+	return &r
+}
+
+// Wait is an utility method that calls the rater function itself.
+// It's meant to aid readability.
+func (r *FixedRater) Wait(began, now time.Time) time.Duration {
+	if r.hits != 0 && r.count == r.hits {
+		return -1
+	}
+
+	r.count++
+	interval := uint64(r.rate.Per.Nanoseconds() / int64(r.rate.Freq))
+	delta := time.Duration(r.count * interval)
+
+	if wait := began.Add(delta).Sub(now); wait > 0 {
+		return wait
+	}
+
+	return 0
 }
 
 // Rate sends a constant rate of hits to the target.
@@ -234,29 +276,6 @@ func (r Rate) IsZero() bool {
 	return r.Freq == 0 || r.Per == 0
 }
 
-// Interval implements part of the Rater interface. It calculates the time
-// between each hit from r.Per / r.Freq and multiplies this by the count of
-// hits already elapsed to determine the absolute time when the next hit should
-// occur. It returns the Duration until that time.
-func (r Rate) Interval(began time.Time, count uint64) time.Duration {
-	return r.interval(began, time.Now(), count)
-}
-
-func (r Rate) interval(began, now time.Time, count uint64) time.Duration {
-	delta := time.Duration(count * uint64(r.Per.Nanoseconds()/int64(r.Freq)))
-	return began.Add(delta).Sub(now)
-}
-
-// Hits implements part of the Rater interface. It returns the number of hits
-// the attacker is expected to send when applying this Rate over the provided
-// Duration.
-func (r Rate) Hits(du time.Duration) uint64 {
-	if du == 0 || r.IsZero() {
-		return 0
-	}
-	return uint64(du) / (uint64(r.Per.Nanoseconds() / int64(r.Freq)))
-}
-
 // String returns a pretty-printed description of the rate, e.g.:
 //   Rate{1 hits/1s} for Rate{Freq:1, Per: time.Second}
 func (r Rate) String() string {
@@ -264,13 +283,13 @@ func (r Rate) String() string {
 }
 
 // Attack reads its Targets from the passed Targeter and attacks them at
-// the rate specified for the given duration. When the duration is zero the attack
-// runs until Stop is called. Results are sent to the returned channel as soon
-// as they arrive and will have their Attack field set to the given name.
-func (a *Attacker) Attack(tr Targeter, r Rater, du time.Duration, name string) <-chan *Result {
+// the rate produced by the given Rater. Results are sent to the returned
+// channel as soon as they arrive and will have their Attack field set to
+// the given name.
+func (a *Attacker) Attack(tr Targeter, r Rater, name string) <-chan *Result {
 	var workers sync.WaitGroup
 	results := make(chan *Result)
-	ticks := make(chan uint64)
+	ticks := make(chan struct{})
 	for i := uint64(0); i < a.workers; i++ {
 		workers.Add(1)
 		go a.attack(tr, name, &workers, ticks, results)
@@ -280,15 +299,16 @@ func (a *Attacker) Attack(tr Targeter, r Rater, du time.Duration, name string) <
 		defer close(results)
 		defer workers.Wait()
 		defer close(ticks)
-		hits := r.Hits(du)
-		began, count := time.Now(), uint64(0)
+		began := time.Now()
 		for {
-			time.Sleep(r.Interval(began, count))
+			wait := r.Wait(began, time.Now())
+			if wait < 0 {
+				return
+			}
+			time.Sleep(wait)
+
 			select {
-			case ticks <- count:
-				if count++; count == hits {
-					return
-				}
+			case ticks <- struct{}{}:
 			case <-a.stopch:
 				return
 			default: // all workers are blocked. start one more and try again
@@ -311,7 +331,7 @@ func (a *Attacker) Stop() {
 	}
 }
 
-func (a *Attacker) attack(tr Targeter, name string, workers *sync.WaitGroup, ticks <-chan uint64, results chan<- *Result) {
+func (a *Attacker) attack(tr Targeter, name string, workers *sync.WaitGroup, ticks <-chan struct{}, results chan<- *Result) {
 	defer workers.Done()
 	for range ticks {
 		results <- a.hit(tr, name)

--- a/lib/attack.go
+++ b/lib/attack.go
@@ -267,8 +267,7 @@ func (r *FixedRater) Wait(began, now time.Time) time.Duration {
 	}
 
 	r.count++
-	interval := uint64(r.rate.Per.Nanoseconds() / int64(r.rate.Freq))
-	delta := time.Duration(r.count * interval)
+	delta := time.Duration(r.count) * r.rate.Interval()
 
 	if wait := began.Add(delta).Sub(now); wait > 0 {
 		return wait
@@ -281,6 +280,11 @@ func (r *FixedRater) Wait(began, now time.Time) time.Duration {
 type Rate struct {
 	Freq int           // Frequency (number of occurrences) per ...
 	Per  time.Duration // Time unit, usually 1s
+}
+
+// Interval returns the duration this rate represents.
+func (r Rate) Interval() time.Duration {
+	return time.Duration(r.Per.Nanoseconds() / int64(r.Freq))
 }
 
 // IsZero returns true if either Freq or Per are zero valued.

--- a/lib/attack_test.go
+++ b/lib/attack_test.go
@@ -303,3 +303,58 @@ func TestClient(t *testing.T) {
 		t.Errorf("Expected timeout error")
 	}
 }
+
+func TestRateInterval(t *testing.T) {
+	t.Parallel()
+	began := time.Now()
+
+	for i, tt := range []struct {
+		freq  int
+		per   time.Duration
+		count uint64
+		since time.Duration
+		want  time.Duration
+	}{
+		// 1 hit/sec, 0 hits sent, 1s elapsed => -1s until next hit
+		// (time.Sleep will return immediately in this case)
+		{1, time.Second, 0, time.Second, -time.Second},
+		// 1 hit/sec, 1 hit sent, 1s elapsed => 0s until next hit
+		{1, time.Second, 1, time.Second, 0},
+		// 1 hit/sec, 2 hits sent, 1s elapsed => 1s until next hit
+		{1, time.Second, 2, time.Second, time.Second},
+		// 1 hit/sec, 10 hits sent, 1s elapsed => 9s until next hit
+		{1, time.Second, 10, time.Second, 9 * time.Second},
+		// 1 hit/sec, 10 hits sent, 10s elapsed => 0s until next hit
+		{1, time.Second, 10, 10 * time.Second, 0},
+		// 2 hit/sec, 9 hits sent, 4.4s elapsed => 100ms until next hit
+		{2, time.Second, 9, (44 * time.Second) / 10, 100 * time.Millisecond},
+	} {
+		r := Rate{Freq: tt.freq, Per: tt.per}
+		got := r.interval(began, began.Add(tt.since), tt.count)
+		if got != tt.want {
+			t.Errorf("%d: %v.Interval(%v, %d) = %v; want %v",
+				i, r, tt.since, tt.count, got, tt.want)
+		}
+	}
+}
+
+func TestRateHits(t *testing.T) {
+	for i, tt := range []struct {
+		freq int
+		per  time.Duration
+		du   time.Duration
+		want uint64
+	}{
+		{1, time.Second, 0, 0},
+		{1, time.Second, time.Second, 1},
+		{2, time.Second, time.Second, 2},
+		{1, time.Second, 10 * time.Second, 10},
+		{100, time.Second, 100 * time.Second, 100 * 100},
+	} {
+		r := Rate{Freq: tt.freq, Per: tt.per}
+		got := r.Hits(tt.du)
+		if got != tt.want {
+			t.Errorf("%d: %v.Hits(%v) = %d; want %d", i, r, tt.du, got, tt.want)
+		}
+	}
+}

--- a/lib/attack_test.go
+++ b/lib/attack_test.go
@@ -25,7 +25,7 @@ func TestAttackRate(t *testing.T) {
 	rate := Rate{Freq: 100, Per: time.Second}
 	atk := NewAttacker()
 	var hits uint64
-	for range atk.Attack(tr, rate, 1*time.Second, "") {
+	for range atk.Attack(tr, NewFixedRater(rate, time.Second), "") {
 		hits++
 	}
 	if got, want := hits, uint64(rate.Freq); got != want {
@@ -45,7 +45,7 @@ func TestAttackDuration(t *testing.T) {
 	rate := Rate{Freq: 100, Per: time.Second}
 
 	var m Metrics
-	for res := range atk.Attack(tr, rate, rate.Per, "") {
+	for res := range atk.Attack(tr, NewFixedRater(rate, rate.Per), "") {
 		m.Add(res)
 	}
 	m.Close()
@@ -279,8 +279,8 @@ func TestClient(t *testing.T) {
 	client := &http.Client{
 		Timeout: time.Duration(1 * time.Nanosecond),
 		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			Dial:  dialer.Dial,
+			Proxy:                 http.ProxyFromEnvironment,
+			Dial:                  dialer.Dial,
 			ResponseHeaderTimeout: DefaultTimeout,
 			TLSClientConfig:       DefaultTLSConfig,
 			TLSHandshakeTimeout:   10 * time.Second,
@@ -304,57 +304,44 @@ func TestClient(t *testing.T) {
 	}
 }
 
-func TestRateInterval(t *testing.T) {
+func TestFixedRater(t *testing.T) {
 	t.Parallel()
 	began := time.Now()
 
 	for i, tt := range []struct {
-		freq  int
-		per   time.Duration
-		count uint64
-		since time.Duration
-		want  time.Duration
+		freq    int
+		per     time.Duration
+		hits    int
+		du      time.Duration
+		elapsed time.Duration
+		wait    time.Duration
 	}{
-		// 1 hit/sec, 0 hits sent, 1s elapsed => -1s until next hit
+		// Total duration has elapsed.
+		{1, time.Second, 2, time.Second, time.Second, -1},
+		// 1 hit/sec, 0 hits sent, 1s elapsed => 0s until next hit
 		// (time.Sleep will return immediately in this case)
-		{1, time.Second, 0, time.Second, -time.Second},
+		{1, time.Second, 0, 0, time.Second, 0},
 		// 1 hit/sec, 1 hit sent, 1s elapsed => 0s until next hit
-		{1, time.Second, 1, time.Second, 0},
+		{1, time.Second, 1, 0, time.Second, 0},
 		// 1 hit/sec, 2 hits sent, 1s elapsed => 1s until next hit
-		{1, time.Second, 2, time.Second, time.Second},
+		{1, time.Second, 2, 0, time.Second, time.Second},
 		// 1 hit/sec, 10 hits sent, 1s elapsed => 9s until next hit
-		{1, time.Second, 10, time.Second, 9 * time.Second},
+		{1, time.Second, 10, 0, time.Second, 9 * time.Second},
 		// 1 hit/sec, 10 hits sent, 10s elapsed => 0s until next hit
-		{1, time.Second, 10, 10 * time.Second, 0},
+		{1, time.Second, 10, 0, 10 * time.Second, 0},
 		// 2 hit/sec, 9 hits sent, 4.4s elapsed => 100ms until next hit
-		{2, time.Second, 9, (44 * time.Second) / 10, 100 * time.Millisecond},
+		{2, time.Second, 9, 0, (44 * time.Second) / 10, 100 * time.Millisecond},
 	} {
-		r := Rate{Freq: tt.freq, Per: tt.per}
-		got := r.interval(began, began.Add(tt.since), tt.count)
-		if got != tt.want {
-			t.Errorf("%d: %v.Interval(%v, %d) = %v; want %v",
-				i, r, tt.since, tt.count, got, tt.want)
-		}
-	}
-}
+		rt := Rate{Freq: tt.freq, Per: tt.per}
+		r := NewFixedRater(rt, tt.du)
 
-func TestRateHits(t *testing.T) {
-	for i, tt := range []struct {
-		freq int
-		per  time.Duration
-		du   time.Duration
-		want uint64
-	}{
-		{1, time.Second, 0, 0},
-		{1, time.Second, time.Second, 1},
-		{2, time.Second, time.Second, 2},
-		{1, time.Second, 10 * time.Second, 10},
-		{100, time.Second, 100 * time.Second, 100 * 100},
-	} {
-		r := Rate{Freq: tt.freq, Per: tt.per}
-		got := r.Hits(tt.du)
-		if got != tt.want {
-			t.Errorf("%d: %v.Hits(%v) = %d; want %d", i, r, tt.du, got, tt.want)
+		for i := 0; i < tt.hits-1; i++ {
+			r.Wait(began, time.Now())
+		}
+
+		wait := r.Wait(began, began.Add(tt.elapsed))
+		if have, want := wait, tt.wait; have != want {
+			t.Errorf("test case %d: %+v: have %v, want %v", i, r, have, want)
 		}
 	}
 }


### PR DESCRIPTION
This commit introduces a Rater interface which allows library users to
implement alternative attack paces besides the original fixed rate.

Based on #380