### PR TITLE
Add ARM 32bits architecture

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,7 @@ builds:
   goarch:
   - amd64
   - arm64
+  - arm
   env:
   - CGO_ENABLED=0
   flags:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,8 @@ builds:
   - amd64
   - arm64
   - arm
+  goarm:
+  - 7
   env:
   - CGO_ENABLED=0
   flags:


### PR DESCRIPTION
#### Background

To run inside a raspberry pi, the source code needs to be compiled for arm 32bits.

Tested on a raspberry pi 3b+ with the `HypriotOS/armv7` distro.

Are you able to provide the pre-compiled executable for ARM32 as well?

Thanks

#### Checklist

- [X] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [X] Each Git commit represents meaningful milestones or atomic units of work.
- [X] Changed or added code is covered by appropriate tests.
