### PR TITLE
main: Bugfix: Print all command line help text to stderr, not stdout

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,8 +26,8 @@ func main() {
 	version := fs.Bool("version", false, "Print version and exit")
 
 	fs.Usage = func() {
-		fmt.Println("Usage: vegeta [global flags] <command> [command flags]")
-		fmt.Printf("\nglobal flags:\n")
+		fmt.Fprintln(fs.Output(), "Usage: vegeta [global flags] <command> [command flags]")
+		fmt.Fprintf(fs.Output(), "\nglobal flags:\n")
 		fs.PrintDefaults()
 
 		names := make([]string, 0, len(commands))
@@ -38,12 +38,13 @@ func main() {
 		sort.Strings(names)
 		for _, name := range names {
 			if cmd := commands[name]; cmd.fs != nil {
-				fmt.Printf("\n%s command:\n", name)
+				fmt.Fprintf(fs.Output(),"\n%s command:\n", name)
+				cmd.fs.SetOutput(fs.Output())
 				cmd.fs.PrintDefaults()
 			}
 		}
 
-		fmt.Println(examples)
+		fmt.Fprintln(fs.Output(), examples)
 	}
 
 	fs.Parse(os.Args[1:])


### PR DESCRIPTION
Previously some was printed to stderr, some was printed to stdout.

This caused the help text to be garbled sometimes, e.g. in certain terminals. Before fix:

![image](https://user-images.githubusercontent.com/389616/56550030-60051d80-6539-11e9-89f3-1f438f0bcdbe.png)

After fix:

![image](https://user-images.githubusercontent.com/389616/56550039-672c2b80-6539-11e9-9b52-9cc0dde8d62c.png)

(Actually I first noticed this when running vegeta on a remote system using something like [fabric](http://www.fabfile.org/), where stdout and stderr are captured separately and returned as two strings, so any interleaving gets lost.)


#### Background

<!-- Required background information to understand the PR. Link here any related issues. -->

#### Checklist

- [ ] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] Each Git commit represents meaningful milestones or atomic units of work.
- [ ] Changed or added code is covered by appropriate tests.