### PR TITLE
attack: Benchmarking with -rate=0 and -max-workers=N

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,87 +51,87 @@ Usage: vegeta [global flags] <command> [command flags]
 
 global flags:
   -cpus int
-        Number of CPUs to use (defaults to the number of CPUs you have)
+    	Number of CPUs to use (defaults to the number of CPUs you have)
   -profile string
-        Enable profiling of [cpu, heap]
+    	Enable profiling of [cpu, heap]
   -version
-        Print version and exit
+    	Print version and exit
 
 attack command:
   -body string
-        Requests body file
+    	Requests body file
   -cert string
-        TLS client PEM encoded certificate file
+    	TLS client PEM encoded certificate file
   -connections int
-        Max open idle connections per target host (default 10000)
+    	Max open idle connections per target host (default 10000)
   -duration duration
-        Duration of the test [0 = forever]
+    	Duration of the test [0 = forever]
   -format string
-        Targets format [http, json] (default "http")
+    	Targets format [http, json] (default "http")
   -h2c
-        Send HTTP/2 requests without TLS encryption
+    	Send HTTP/2 requests without TLS encryption
   -header value
-        Request header
+    	Request header
   -http2
-        Send HTTP/2 requests when supported by the server (default true)
+    	Send HTTP/2 requests when supported by the server (default true)
   -insecure
-        Ignore invalid server TLS certificates
+    	Ignore invalid server TLS certificates
   -keepalive
-        Use persistent connections (default true)
+    	Use persistent connections (default true)
   -key string
-        TLS client PEM encoded private key file
+    	TLS client PEM encoded private key file
   -laddr value
-        Local IP address (default 0.0.0.0)
+    	Local IP address (default 0.0.0.0)
   -lazy
-        Read targets lazily
+    	Read targets lazily
   -max-body value
-        Maximum number of bytes to capture from response bodies. [-1 = no limit] (default -1)
+    	Maximum number of bytes to capture from response bodies. [-1 = no limit] (default -1)
   -max-workers uint
-        Maximum number of workers (default 18446744073709551615)
+    	Maximum number of workers (default 18446744073709551615)
   -name string
-        Attack name
+    	Attack name
   -output string
-        Output file (default "stdout")
+    	Output file (default "stdout")
   -rate value
-        Number of requests per time unit (default 50/1s)
+    	Number of requests per time unit [0 = infinity] (default 50/1s)
   -redirects int
-        Number of redirects to follow. -1 will not follow but marks as success (default 10)
+    	Number of redirects to follow. -1 will not follow but marks as success (default 10)
   -resolvers value
-        List of addresses (ip:port) to use for DNS resolution. Disables use of local system DNS. (comma separated list)
+    	List of addresses (ip:port) to use for DNS resolution. Disables use of local system DNS. (comma separated list)
   -root-certs value
-        TLS root certificate files (comma separated list)
+    	TLS root certificate files (comma separated list)
   -targets string
-        Targets file (default "stdin")
+    	Targets file (default "stdin")
   -timeout duration
-        Requests timeout (default 30s)
+    	Requests timeout (default 30s)
   -unix-socket string
-        Connect over a unix socket. This overrides the host address in target URLs
+    	Connect over a unix socket. This overrides the host address in target URLs
   -workers uint
-        Initial number of workers (default 10)
+    	Initial number of workers (default 10)
 
 encode command:
   -output string
-        Output file (default "stdout")
+    	Output file (default "stdout")
   -to string
-        Output encoding [csv, gob, json] (default "json")
+    	Output encoding [csv, gob, json] (default "json")
 
 plot command:
   -output string
-        Output file (default "stdout")
+    	Output file (default "stdout")
   -threshold int
-        Threshold of data points above which series are downsampled. (default 4000)
+    	Threshold of data points above which series are downsampled. (default 4000)
   -title string
-        Title and header of the resulting HTML page (default "Vegeta Plot")
+    	Title and header of the resulting HTML page (default "Vegeta Plot")
 
 report command:
   -buckets string
-        Histogram buckets, e.g.: "[0,1ms,10ms]"
+    	Histogram buckets, e.g.: "[0,1ms,10ms]"
   -every duration
-        Report interval
+    	Report interval
   -output string
-        Output file (default "stdout")
+    	Output file (default "stdout")
   -type string
-        Report type to generate [text, json, hist[buckets], hdrplot] (default "text")
+    	Report type to generate [text, json, hist[buckets], hdrplot] (default "text")
 
 examples:
   echo "GET http://localhost/" | vegeta attack -duration=5s | tee results.bin | vegeta report
@@ -317,6 +317,13 @@ Specifies the request rate per time unit to issue against
 the targets. The actual request rate can vary slightly due to things like
 garbage collection, but overall it should stay very close to the specified.
 If no time unit is provided, 1s is used.
+
+A `-rate` of `0` or `infinity` means vegeta will send requests as fast as possible.
+Use together with `-max-workers` to model a fixed set of concurrent users sending
+requests serially (i.e. waiting for a response before sending the next request).
+
+Setting `-max-workers` to a very high number while setting `-rate=0` can result in
+vegeta consuming too many resources and crashing. Use with care.
 
 #### `-redirects`
 

--- a/attack.go
+++ b/attack.go
@@ -97,8 +97,8 @@ type attackOpts struct {
 // attack validates the attack arguments, sets up the
 // required resources, launches the attack and writes the results
 func attack(opts *attackOpts) (err error) {
-	if opts.rate.Per <= 0 || opts.rate.Freq <= 0 {
-		return errZeroRate
+	if opts.maxWorkers == vegeta.DefaultMaxWorkers && opts.rate.Freq == 0 {
+		return fmt.Errorf("-rate=0 requires setting -max-workers")
 	}
 
 	if len(opts.resolvers) > 0 {

--- a/attack.go
+++ b/attack.go
@@ -47,7 +47,7 @@ func attackCmd() command {
 	fs.IntVar(&opts.connections, "connections", vegeta.DefaultConnections, "Max open idle connections per target host")
 	fs.IntVar(&opts.redirects, "redirects", vegeta.DefaultRedirects, "Number of redirects to follow. -1 will not follow but marks as success")
 	fs.Var(&maxBodyFlag{&opts.maxBody}, "max-body", "Maximum number of bytes to capture from response bodies. [-1 = no limit]")
-	fs.Var(&rateFlag{&opts.rate}, "rate", "Number of requests per time unit")
+	fs.Var(&rateFlag{&opts.rate}, "rate", "Number of requests per time unit [0 = infinity]")
 	fs.Var(&opts.headers, "header", "Request header")
 	fs.Var(&opts.laddr, "laddr", "Local IP address")
 	fs.BoolVar(&opts.keepalive, "keepalive", true, "Use persistent connections")

--- a/flags.go
+++ b/flags.go
@@ -79,6 +79,10 @@ func (f *rateFlag) Set(v string) (err error) {
 		return err
 	}
 
+	if f.Freq == 0 {
+		return nil
+	}
+
 	switch ps[1] {
 	case "ns", "us", "µs", "ms", "s", "m", "h":
 		ps[1] = "1" + ps[1]

--- a/flags.go
+++ b/flags.go
@@ -66,6 +66,10 @@ func (l csl) String() string { return strings.Join(l, ",") }
 type rateFlag struct{ *vegeta.Rate }
 
 func (f *rateFlag) Set(v string) (err error) {
+	if v == "infinity" {
+		return nil
+	}
+
 	ps := strings.SplitN(v, "/", 2)
 	switch len(ps) {
 	case 1:

--- a/internal/cmd/echosrv/main.go
+++ b/internal/cmd/echosrv/main.go
@@ -1,7 +1,12 @@
 package main
 
 import (
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
 	"flag"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -11,6 +16,7 @@ import (
 
 func main() {
 	sleep := flag.Duration("sleep", 0, "Time to sleep per request")
+	work := flag.Int("work", 0, "Artificial work load iteration count")
 
 	flag.Parse()
 
@@ -26,9 +32,36 @@ func main() {
 
 	http.ListenAndServe(flag.Arg(0), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer atomic.AddUint64(&count, 1)
+
 		time.Sleep(*sleep)
+
+		if _, err := hash(*work); err != nil {
+			log.Printf("Error: %s", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 
 		bs, _ := httputil.DumpRequest(r, true)
 		w.Write(bs)
 	}))
+}
+
+func hash(n int) (string, error) {
+	if n == 0 {
+		return "", nil
+	}
+
+	var buf bytes.Buffer
+	_, err := io.CopyN(&buf, rand.Reader, 1024*1024) // 1MB
+	if err != nil {
+		return "", err
+	}
+
+	data := buf.Bytes()
+	for i := 0; i < n; i++ {
+		hash := sha256.Sum256(data)
+		data = hash[:]
+	}
+
+	return base64.URLEncoding.EncodeToString(data), nil
 }

--- a/lib/pacer.go
+++ b/lib/pacer.go
@@ -43,10 +43,13 @@ func (cp ConstantPacer) String() string {
 
 // Pace determines the length of time to sleep until the next hit is sent.
 func (cp ConstantPacer) Pace(elapsed time.Duration, hits uint64) (time.Duration, bool) {
-	if cp.Per <= 0 || cp.Freq <= 0 {
-		// If pacer configuration is invalid, stop the attack.
+	switch {
+	case cp.Per == 0 || cp.Freq == 0:
+		return 0, false // Zero value = infinite rate
+	case cp.Per < 0 || cp.Freq < 0:
 		return 0, true
 	}
+
 	expectedHits := uint64(cp.Freq) * uint64(elapsed/cp.Per)
 	if hits < expectedHits {
 		// Running behind, send next hit immediately.

--- a/lib/pacer_test.go
+++ b/lib/pacer_test.go
@@ -37,11 +37,11 @@ func TestConstantPacer(t *testing.T) {
 
 		// :-( SAD PATH TESTS :-(
 		// Zero frequency.
-		{0, time.Second, time.Second, 0, 0, true},
+		{0, time.Second, time.Second, 0, 0, false},
 		// Zero per.
-		{1, 0, time.Second, 0, 0, true},
+		{1, 0, time.Second, 0, 0, false},
 		// Zero frequency + per.
-		{0, 0, time.Second, 0, 0, true},
+		{0, 0, time.Second, 0, 0, false},
 		// Negative frequency.
 		{-1, time.Second, time.Second, 0, 0, true},
 		// Negative per.


### PR DESCRIPTION
This commit allows setting a zero rate which, together with a reasonable
number of `-max-workers`, behaves as independent concurrent users, each
sending a request and waiting for the response before sending the next
one.

This is part of enabling vegeta to work with the Universal Scalability
Law model, where a concurrency unit is defined as an independent
thread/worker/driver as described above (i.e. with backpressure).

Fixes #378