### PR TITLE
Support HTTP CONNECT proxy headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ attack command:
     	Attack name
   -output string
     	Output file (default "stdout")
-  -proxy-headers value
-    	Headers for the CONNECT request
+  -proxy-header value
+    	Header for the CONNECT request
   -rate value
     	Number of requests per time unit [0 = infinity] (default 50/1s)
   -redirects int

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ attack command:
   -output string
     	Output file (default "stdout")
   -proxy-header value
-    	Header for the CONNECT request
+    	Proxy CONNECT header
   -rate value
     	Number of requests per time unit [0 = infinity] (default 50/1s)
   -redirects int

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ attack command:
     	Attack name
   -output string
     	Output file (default "stdout")
+  -proxy-headers value
+    	Headers for the CONNECT request
   -rate value
     	Number of requests per time unit [0 = infinity] (default 50/1s)
   -redirects int

--- a/attack.go
+++ b/attack.go
@@ -22,11 +22,11 @@ import (
 func attackCmd() command {
 	fs := flag.NewFlagSet("vegeta attack", flag.ExitOnError)
 	opts := &attackOpts{
-		headers: headers{http.Header{}},
+		headers:      headers{http.Header{}},
 		proxyHeaders: headers{http.Header{}},
-		laddr:   localAddr{&vegeta.DefaultLocalAddr},
-		rate:    vegeta.Rate{Freq: 50, Per: time.Second},
-		maxBody: vegeta.DefaultMaxBody,
+		laddr:        localAddr{&vegeta.DefaultLocalAddr},
+		rate:         vegeta.Rate{Freq: 50, Per: time.Second},
+		maxBody:      vegeta.DefaultMaxBody,
 	}
 	fs.StringVar(&opts.name, "name", "", "Attack name")
 	fs.StringVar(&opts.targetsf, "targets", "stdin", "Targets file")
@@ -133,9 +133,9 @@ func attack(opts *attackOpts) (err error) {
 	}
 
 	var (
-		tr  vegeta.Targeter
-		src = files[opts.targetsf]
-		hdr = opts.headers.Header
+		tr       vegeta.Targeter
+		src      = files[opts.targetsf]
+		hdr      = opts.headers.Header
 		proxyHdr = opts.proxyHeaders.Header
 	)
 
@@ -181,7 +181,7 @@ func attack(opts *attackOpts) (err error) {
 		vegeta.H2C(opts.h2c),
 		vegeta.MaxBody(opts.maxBody),
 		vegeta.UnixSocket(opts.unixSocket),
-		vegeta.ProxyHdr(&proxyHdr),
+		vegeta.ProxyHeader(proxyHdr),
 	)
 
 	res := atk.Attack(tr, opts.rate, opts.duration, opts.name)

--- a/attack.go
+++ b/attack.go
@@ -23,6 +23,7 @@ func attackCmd() command {
 	fs := flag.NewFlagSet("vegeta attack", flag.ExitOnError)
 	opts := &attackOpts{
 		headers: headers{http.Header{}},
+		proxyHeaders: headers{http.Header{}},
 		laddr:   localAddr{&vegeta.DefaultLocalAddr},
 		rate:    vegeta.Rate{Freq: 50, Per: time.Second},
 		maxBody: vegeta.DefaultMaxBody,
@@ -49,6 +50,7 @@ func attackCmd() command {
 	fs.Var(&maxBodyFlag{&opts.maxBody}, "max-body", "Maximum number of bytes to capture from response bodies. [-1 = no limit]")
 	fs.Var(&rateFlag{&opts.rate}, "rate", "Number of requests per time unit [0 = infinity]")
 	fs.Var(&opts.headers, "header", "Request header")
+	fs.Var(&opts.proxyHeaders, "proxy-header", "Proxy CONNECT header")
 	fs.Var(&opts.laddr, "laddr", "Local IP address")
 	fs.BoolVar(&opts.keepalive, "keepalive", true, "Use persistent connections")
 	fs.StringVar(&opts.unixSocket, "unix-socket", "", "Connect over a unix socket. This overrides the host address in target URLs")
@@ -67,31 +69,32 @@ var (
 
 // attackOpts aggregates the attack function command options
 type attackOpts struct {
-	name        string
-	targetsf    string
-	format      string
-	outputf     string
-	bodyf       string
-	certf       string
-	keyf        string
-	rootCerts   csl
-	http2       bool
-	h2c         bool
-	insecure    bool
-	lazy        bool
-	duration    time.Duration
-	timeout     time.Duration
-	rate        vegeta.Rate
-	workers     uint64
-	maxWorkers  uint64
-	connections int
-	redirects   int
-	maxBody     int64
-	headers     headers
-	laddr       localAddr
-	keepalive   bool
-	resolvers   csl
-	unixSocket  string
+	name         string
+	targetsf     string
+	format       string
+	outputf      string
+	bodyf        string
+	certf        string
+	keyf         string
+	rootCerts    csl
+	http2        bool
+	h2c          bool
+	insecure     bool
+	lazy         bool
+	duration     time.Duration
+	timeout      time.Duration
+	rate         vegeta.Rate
+	workers      uint64
+	maxWorkers   uint64
+	connections  int
+	redirects    int
+	maxBody      int64
+	headers      headers
+	proxyHeaders headers
+	laddr        localAddr
+	keepalive    bool
+	resolvers    csl
+	unixSocket   string
 }
 
 // attack validates the attack arguments, sets up the
@@ -133,6 +136,7 @@ func attack(opts *attackOpts) (err error) {
 		tr  vegeta.Targeter
 		src = files[opts.targetsf]
 		hdr = opts.headers.Header
+		proxyHdr = opts.proxyHeaders.Header
 	)
 
 	switch opts.format {
@@ -177,6 +181,7 @@ func attack(opts *attackOpts) (err error) {
 		vegeta.H2C(opts.h2c),
 		vegeta.MaxBody(opts.maxBody),
 		vegeta.UnixSocket(opts.unixSocket),
+		vegeta.ProxyHdr(&proxyHdr),
 	)
 
 	res := atk.Attack(tr, opts.rate, opts.duration, opts.name)

--- a/lib/attack.go
+++ b/lib/attack.go
@@ -229,12 +229,13 @@ func Client(c *http.Client) func(*Attacker) {
 	return func(a *Attacker) { a.client = *c }
 }
 
-// ProxyHdr returns a functional option that allows you to add your own
+// ProxyHeader returns a functional option that allows you to add your own
 // Proxy CONNECT headers
-func ProxyHdr(h *http.Header) func(*Attacker) {
+func ProxyHeader(h http.Header) func(*Attacker) {
 	return func(a *Attacker) {
-		tr := a.client.Transport.(*http.Transport)
-		tr.ProxyConnectHeader = *h
+		if tr, ok := a.client.Transport.(*http.Transport); ok {
+			tr.ProxyConnectHeader = h
+		}
 	}
 }
 

--- a/lib/attack.go
+++ b/lib/attack.go
@@ -229,6 +229,15 @@ func Client(c *http.Client) func(*Attacker) {
 	return func(a *Attacker) { a.client = *c }
 }
 
+// ProxyHdr returns a functional option that allows you to add your own
+// Proxy CONNECT headers
+func ProxyHdr(h *http.Header) func(*Attacker) {
+	return func(a *Attacker) {
+		tr := a.client.Transport.(*http.Transport)
+		tr.ProxyConnectHeader = *h
+	}
+}
+
 // Attack reads its Targets from the passed Targeter and attacks them at
 // the rate specified by the Pacer. When the duration is zero the attack
 // runs until Stop is called. Results are sent to the returned channel as soon

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 		sort.Strings(names)
 		for _, name := range names {
 			if cmd := commands[name]; cmd.fs != nil {
-				fmt.Fprintf(fs.Output(),"\n%s command:\n", name)
+				fmt.Fprintf(fs.Output(), "\n%s command:\n", name)
 				cmd.fs.SetOutput(fs.Output())
 				cmd.fs.PrintDefaults()
 			}


### PR DESCRIPTION
#### Background

This PR adds support for proxy CONNECT headers. This allows sending custom headers to the proxy using the `-proxy-header` flag. Multiple headers can be sent by reusing the flag. Fixes https://github.com/tsenart/vegeta/issues/416

Example:
```
export HTTPS_PROXY=http://localhost:12345
./vegeta attack -duration=1s -insecure -targets=targets.txt -proxy-headers "Header1:Key1" -proxy-headers "Header2:key2"
[tmp] nc -lv 12345
CONNECT www.example.com:443 HTTP/1.1
Host: www.example.com:443
User-Agent: Go-http-client/1.1
Header1: Key1
Header2: key2
