### PR TITLE
Fix comments between headers (#447)

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,13 +250,15 @@ X-Account-ID: 99
 @/path/to/newthing.json
 ```
 
-###### Add comments to the targets
+###### Add comments
 
 Lines starting with `#` are ignored.
 
 ```
 # get a dragon ball
 GET http://goku:9090/path/to/dragon?item=ball
+# specify a test accout
+X-Account-ID: 99
 ```
 
 #### `-h2c`

--- a/lib/targets.go
+++ b/lib/targets.go
@@ -300,6 +300,8 @@ func NewHTTPTargeter(src io.Reader, body []byte, hdr http.Header) Targeter {
 		for sc.Scan() {
 			if line = strings.TrimSpace(sc.Text()); line == "" {
 				break
+			} else if strings.HasPrefix(line, "#") {
+				continue
 			} else if strings.HasPrefix(line, "@") {
 				if tgt.Body, err = ioutil.ReadFile(line[1:]); err != nil {
 					return fmt.Errorf("bad body: %s", err)

--- a/lib/targets_test.go
+++ b/lib/targets_test.go
@@ -315,6 +315,13 @@ func TestNewHTTPTargeter(t *testing.T) {
 		GET http://:6060/
 		X-Header: 1
 		X-Header: 2`,
+		`
+
+		GET http://:8000/
+		# This is a comment. Lines starting with hash pound are ignored even inside the target.
+		X-Header: 1
+		# Another comment.
+		X-Header: 2`,
 	)
 
 	src := bytes.NewBufferString(strings.TrimSpace(targets))
@@ -368,6 +375,15 @@ func TestNewHTTPTargeter(t *testing.T) {
 		{ // Preceeding comment is ignored and target is parsed correctly.
 			Method: "GET",
 			URL:    "http://:6060/",
+			Body:   []byte{},
+			Header: http.Header{
+				"X-Header":     []string{"1", "2"},
+				"Content-Type": []string{"text/plain"},
+			},
+		},
+		{
+			Method: "GET",
+			URL:    "http://:8000/",
 			Body:   []byte{},
 			Header: http.Header{
 				"X-Header":     []string{"1", "2"},


### PR DESCRIPTION
#### Background

Closes issue #447

Sometimes is nice to provide more information about a specific header, specially when sharing targets files. For this reason would be nice be able to put comments in the header section.

#### Checklist

- [x] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] Each Git commit represents meaningful milestones or atomic units of work.
- [x] Changed or added code is covered by appropriate tests.
