### PR TITLE
attack: Implement the -chunked flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ attack command:
     	Requests body file
   -cert string
     	TLS client PEM encoded certificate file
+  -chunked
+    	Send body with chunked transfer encoding
   -connections int
     	Max open idle connections per target host (default 10000)
   -duration duration
@@ -167,6 +169,10 @@ request unless overridden per attack target, see `-targets`.
 
 Specifies the PEM encoded TLS client certificate file to be used with HTTPS requests.
 If `-key` isn't specified, it will be set to the value of this flag.
+
+#### `-chunked`
+
+Specifies whether to send request bodies with the chunked transfer encoding.
 
 #### `-connections`
 

--- a/attack.go
+++ b/attack.go
@@ -34,6 +34,7 @@ func attackCmd() command {
 		fmt.Sprintf("Targets format [%s]", strings.Join(vegeta.TargetFormats, ", ")))
 	fs.StringVar(&opts.outputf, "output", "stdout", "Output file")
 	fs.StringVar(&opts.bodyf, "body", "", "Requests body file")
+	fs.BoolVar(&opts.chunked, "chunked", false, "Send body with chunked transfer encoding")
 	fs.StringVar(&opts.certf, "cert", "", "TLS client PEM encoded certificate file")
 	fs.StringVar(&opts.keyf, "key", "", "TLS client PEM encoded private key file")
 	fs.Var(&opts.rootCerts, "root-certs", "TLS root certificate files (comma separated list)")
@@ -81,6 +82,7 @@ type attackOpts struct {
 	h2c          bool
 	insecure     bool
 	lazy         bool
+	chunked      bool
 	duration     time.Duration
 	timeout      time.Duration
 	rate         vegeta.Rate
@@ -182,6 +184,7 @@ func attack(opts *attackOpts) (err error) {
 		vegeta.MaxBody(opts.maxBody),
 		vegeta.UnixSocket(opts.unixSocket),
 		vegeta.ProxyHeader(proxyHdr),
+		vegeta.ChunkedBody(opts.chunked),
 	)
 
 	res := atk.Attack(tr, opts.rate, opts.duration, opts.name)

--- a/internal/cmd/echosrv/main.go
+++ b/internal/cmd/echosrv/main.go
@@ -10,11 +10,13 @@ import (
 	"log"
 	"net/http"
 	"net/http/httputil"
+	"os"
 	"sync/atomic"
 	"time"
 )
 
 func main() {
+	dump := flag.Bool("dump", false, "Dump HTTP requests to stdout")
 	sleep := flag.Duration("sleep", 0, "Time to sleep per request")
 	work := flag.Int("work", 0, "Artificial work load iteration count")
 
@@ -42,7 +44,13 @@ func main() {
 		}
 
 		bs, _ := httputil.DumpRequest(r, true)
-		w.Write(bs)
+
+		out := io.Writer(w)
+		if *dump {
+			out = io.MultiWriter(w, os.Stdout)
+		}
+
+		_, _ = out.Write(bs)
 	}))
 }
 

--- a/lib/targets.go
+++ b/lib/targets.go
@@ -270,7 +270,7 @@ func NewHTTPTargeter(src io.Reader, body []byte, hdr http.Header) Targeter {
 			}
 			line = strings.TrimSpace(sc.Text())
 
-			if len(line) != 0 && line[0] != '#'{
+			if len(line) != 0 && line[0] != '#' {
 				break
 			}
 		}


### PR DESCRIPTION
Some users of vegeta must be able to control how the request body is
sent. By default, the Go HTTP client doesn't make any guarantees about
which transfer encoding is used.

https://sourcegraph.com/github.com/golang/go/-/blob/src/net/http/request.go#L202

Fixes #439