### PR TITLE
Add header to target containing the sequence number

### DIFF
--- a/lib/attack.go
+++ b/lib/attack.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"time"
 
+	"strconv"
+
 	"golang.org/x/net/http2"
 )
 
@@ -331,7 +333,7 @@ func (a *Attacker) attack(tr Targeter, name string, workers *sync.WaitGroup, tic
 func (a *Attacker) hit(tr Targeter, name string) *Result {
 	var (
 		res = Result{Attack: name}
-		tgt Target
+		tgt = Target{Header: make(http.Header)}
 		err error
 	)
 
@@ -347,6 +349,8 @@ func (a *Attacker) hit(tr Targeter, name string) *Result {
 			res.Error = err.Error()
 		}
 	}()
+
+	tgt.Header.Set("X-Vegeta-Seq", strconv.FormatUint(res.Seq, 10))
 
 	if err = tr(&tgt); err != nil {
 		a.Stop()

--- a/lib/attack_test.go
+++ b/lib/attack_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -356,5 +357,23 @@ func TestClient(t *testing.T) {
 	resp := atk.hit(tr, "TEST")
 	if !strings.Contains(resp.Error, "Client.Timeout exceeded while awaiting headers") {
 		t.Errorf("Expected timeout error")
+	}
+}
+
+func TestSeqHeader(t *testing.T) {
+	t.Parallel()
+
+	var got http.Header
+
+	atk := NewAttacker()
+	for i := 0; i < 5; i++ {
+		res := atk.hit(func(trt *Target) error {
+			got = trt.Header
+			return nil
+		}, "")
+
+		if got.Get("X-Vegeta-Seq") != strconv.FormatUint(res.Seq, 10) {
+			t.Fatalf("got: %v, want: %v", got.Get("X-Vegeta-Seq"), res.Seq)
+		}
 	}
 }


### PR DESCRIPTION
#### Background

<!-- Required background information to understand the PR. Link here any related issues. -->

Following up the discussion here https://github.com/tsenart/vegeta/issues/462

This adds the res.Seq to the target headers with the name "X-Vegeta-Seq".
This also add a new unit test to check that the header is equal to the res.Seq.

#### Checklist

- [x] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] Each Git commit represents meaningful milestones or atomic units of work.
- [x] Changed or added code is covered by appropriate tests.
