### PR TITLE
Capture HTTP headers in results

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -26,15 +26,18 @@ automatically.
 
 The CSV encoder doesn't write a header. The columns written by it are:
 
-  1. Unix timestamp in nanoseconds since epoch
-  2. HTTP status code
-  3. Request latency in nanoseconds
-  4. Bytes out
-  5. Bytes in
-  6. Error
-  7. Base64 encoded response body
-  8. Attack name
-  9. Sequence number of request
+   1. Unix timestamp in nanoseconds since epoch
+   2. HTTP status code
+   3. Request latency in nanoseconds
+   4. Bytes out
+   5. Bytes in
+   6. Error
+   7. Base64 encoded response body
+   8. Attack name
+   9. Sequence number of request
+  10. Method
+  11. URL
+  12. Base64 encoded response headers
 
 Arguments:
   <file>  A file with vegeta attack results encoded with one of

--- a/lib/attack.go
+++ b/lib/attack.go
@@ -1,6 +1,7 @@
 package vegeta
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"fmt"
@@ -391,6 +392,10 @@ func (a *Attacker) hit(tr Targeter, name string) *Result {
 	if res.Code = uint16(r.StatusCode); res.Code < 200 || res.Code >= 400 {
 		res.Error = r.Status
 	}
+
+	var hdr bytes.Buffer
+	r.Header.Write(&hdr)
+	res.Headers = hdr.String()
 
 	return &res
 }

--- a/lib/attack.go
+++ b/lib/attack.go
@@ -1,7 +1,6 @@
 package vegeta
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"fmt"
@@ -393,9 +392,7 @@ func (a *Attacker) hit(tr Targeter, name string) *Result {
 		res.Error = r.Status
 	}
 
-	var hdr bytes.Buffer
-	r.Header.Write(&hdr)
-	res.Headers = hdr.String()
+	res.Headers = r.Header
 
 	return &res
 }

--- a/lib/results.go
+++ b/lib/results.go
@@ -7,8 +7,11 @@ import (
 	"encoding/csv"
 	"encoding/gob"
 	"io"
+	"net/http"
+	"net/textproto"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/mailru/easyjson/jlexer"
@@ -32,7 +35,7 @@ type Result struct {
 	Body      []byte        `json:"body"`
 	Method    string        `json:"method"`
 	URL       string        `json:"url"`
-	Headers   string        `json:"headers"`
+	Headers   http.Header   `json:"headers"`
 }
 
 // End returns the time at which a Result ended.
@@ -51,7 +54,29 @@ func (r Result) Equal(other Result) bool {
 		bytes.Equal(r.Body, other.Body) &&
 		r.Method == other.Method &&
 		r.URL == other.URL &&
-		r.Headers == other.Headers
+		headerEqual(r.Headers, other.Headers)
+}
+
+func headerEqual(h1, h2 http.Header) bool {
+	if len(h1) != len(h2) {
+		return false
+	}
+	if h1 == nil || h2 == nil {
+		return h1 == nil && h2 == nil
+	}
+	for key, values1 := range h1 {
+		values2 := h2[key]
+		if len(values1) != len(values2) {
+			return false
+		}
+		for i := range values1 {
+			if values1[i] != values2[i] {
+				return false
+			}
+		}
+	}
+
+	return true
 }
 
 // Results is a slice of Result type elements.
@@ -158,7 +183,7 @@ func NewCSVEncoder(w io.Writer) Encoder {
 			strconv.FormatUint(r.Seq, 10),
 			r.Method,
 			r.URL,
-			base64.StdEncoding.EncodeToString([]byte(r.Headers)),
+			base64.StdEncoding.EncodeToString(headerBytes(r.Headers)),
 		})
 		if err != nil {
 			return err
@@ -168,6 +193,15 @@ func NewCSVEncoder(w io.Writer) Encoder {
 
 		return enc.Error()
 	}
+}
+
+func headerBytes(h http.Header) []byte {
+	if h == nil {
+		return nil
+	}
+	var hdr bytes.Buffer
+	_ = h.Write(&hdr)
+	return append(hdr.Bytes(), '\r', '\n')
 }
 
 // NewCSVDecoder returns a Decoder that decodes CSV encoded Results.
@@ -221,11 +255,13 @@ func NewCSVDecoder(r io.Reader) Decoder {
 		r.Method = rec[9]
 		r.URL = rec[10]
 		if len(rec) > 11 {
-			var hdr []byte
-			if hdr, err = base64.StdEncoding.DecodeString(rec[11]); err != nil {
+			pr := textproto.NewReader(bufio.NewReader(
+				base64.NewDecoder(base64.StdEncoding, strings.NewReader(rec[11]))))
+			hdr, err := pr.ReadMIMEHeader()
+			if err != nil {
 				return err
 			}
-			r.Headers = string(hdr)
+			r.Headers = http.Header(hdr)
 		}
 
 		return err

--- a/lib/results_easyjson.go
+++ b/lib/results_easyjson.go
@@ -4,10 +4,11 @@ package vegeta
 
 import (
 	json "encoding/json"
+	time "time"
+
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	jwriter "github.com/mailru/easyjson/jwriter"
-	time "time"
 )
 
 // suppress unused package warning
@@ -134,6 +135,11 @@ func easyjsonBd1621b8EncodeGithubComTsenartVegetaLib(out *jwriter.Writer, in jso
 		const prefix string = ",\"url\":"
 		out.RawString(prefix)
 		out.String(string(in.URL))
+	}
+	{
+		const prefix string = ",\"headers\":"
+		out.RawString(prefix)
+		out.String(string(in.Headers))
 	}
 	out.RawByte('}')
 }

--- a/lib/results_easyjson.go
+++ b/lib/results_easyjson.go
@@ -4,6 +4,7 @@ package vegeta
 
 import (
 	json "encoding/json"
+	"net/http"
 	time "time"
 
 	easyjson "github.com/mailru/easyjson"
@@ -67,6 +68,8 @@ func easyjsonBd1621b8DecodeGithubComTsenartVegetaLib(in *jlexer.Lexer, out *json
 			out.Method = string(in.String())
 		case "url":
 			out.URL = string(in.String())
+		case "headers":
+			out.Headers = easyjsonUnmarshalHeaders(in)
 		default:
 			in.SkipRecursive()
 		}
@@ -139,9 +142,56 @@ func easyjsonBd1621b8EncodeGithubComTsenartVegetaLib(out *jwriter.Writer, in jso
 	{
 		const prefix string = ",\"headers\":"
 		out.RawString(prefix)
-		out.String(string(in.Headers))
+		easyjsonMarshalHeaders(out, in.Headers)
 	}
 	out.RawByte('}')
+}
+
+func easyjsonUnmarshalHeaders(in *jlexer.Lexer) http.Header {
+	h := http.Header{}
+	in.Delim('[')
+	for !in.IsDelim(']') {
+		for in.IsDelim('{') {
+			in.Delim('{')
+			var key string
+			var values []string
+			for !in.IsDelim('}') {
+				k := in.UnsafeString()
+				in.WantColon()
+				if in.IsNull() {
+					in.Skip()
+					in.WantComma()
+					continue
+				}
+				switch k {
+				case "key":
+					key = in.String()
+				case "value":
+					values = append(values, in.String())
+				}
+				in.WantComma()
+			}
+			h[key] = values
+			in.Delim('}')
+			in.WantComma()
+		}
+	}
+	in.Delim(']')
+	return h
+}
+
+func easyjsonMarshalHeaders(w *jwriter.Writer, h http.Header) {
+	w.RawByte('[')
+	for key, values := range h {
+		for _, value := range values {
+			w.RawString(`{"key":`)
+			w.String(key)
+			w.RawString(`,"value":`)
+			w.String(value)
+			w.RawByte('}')
+		}
+	}
+	w.RawByte(']')
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface

--- a/lib/results_test.go
+++ b/lib/results_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"math/rand"
+	"net/http"
 	"reflect"
 	"testing"
 	"testing/quick"
@@ -76,6 +77,7 @@ func TestResultEncoding(t *testing.T) {
 					BytesOut:  bsOut,
 					Error:     e,
 					Body:      body,
+					Headers:   http.Header{"Foo": []string{"bar"}},
 				}
 
 				var buf bytes.Buffer
@@ -87,6 +89,9 @@ func TestResultEncoding(t *testing.T) {
 				}
 
 				dec := tc.dec(&buf)
+				if dec == nil {
+					t.Fatal("Cannot get decoder")
+				}
 				for j := 0; j < 2; j++ {
 					var got Result
 					if err := dec(&got); err != nil {


### PR DESCRIPTION
Headers are written in wire format. CSV output uses base64 to encode
headers.

Fixes #303
