### PR TITLE
Add the max-connections option

### DIFF
--- a/attack.go
+++ b/attack.go
@@ -47,6 +47,7 @@ func attackCmd() command {
 	fs.Uint64Var(&opts.workers, "workers", vegeta.DefaultWorkers, "Initial number of workers")
 	fs.Uint64Var(&opts.maxWorkers, "max-workers", vegeta.DefaultMaxWorkers, "Maximum number of workers")
 	fs.IntVar(&opts.connections, "connections", vegeta.DefaultConnections, "Max open idle connections per target host")
+	fs.IntVar(&opts.maxConnections, "max-connections", vegeta.DefaultMaxConnections, "Max connections per target host")
 	fs.IntVar(&opts.redirects, "redirects", vegeta.DefaultRedirects, "Number of redirects to follow. -1 will not follow but marks as success")
 	fs.Var(&maxBodyFlag{&opts.maxBody}, "max-body", "Maximum number of bytes to capture from response bodies. [-1 = no limit]")
 	fs.Var(&rateFlag{&opts.rate}, "rate", "Number of requests per time unit [0 = infinity]")
@@ -70,33 +71,34 @@ var (
 
 // attackOpts aggregates the attack function command options
 type attackOpts struct {
-	name         string
-	targetsf     string
-	format       string
-	outputf      string
-	bodyf        string
-	certf        string
-	keyf         string
-	rootCerts    csl
-	http2        bool
-	h2c          bool
-	insecure     bool
-	lazy         bool
-	chunked      bool
-	duration     time.Duration
-	timeout      time.Duration
-	rate         vegeta.Rate
-	workers      uint64
-	maxWorkers   uint64
-	connections  int
-	redirects    int
-	maxBody      int64
-	headers      headers
-	proxyHeaders headers
-	laddr        localAddr
-	keepalive    bool
-	resolvers    csl
-	unixSocket   string
+	name           string
+	targetsf       string
+	format         string
+	outputf        string
+	bodyf          string
+	certf          string
+	keyf           string
+	rootCerts      csl
+	http2          bool
+	h2c            bool
+	insecure       bool
+	lazy           bool
+	chunked        bool
+	duration       time.Duration
+	timeout        time.Duration
+	rate           vegeta.Rate
+	workers        uint64
+	maxWorkers     uint64
+	connections    int
+	maxConnections int
+	redirects      int
+	maxBody        int64
+	headers        headers
+	proxyHeaders   headers
+	laddr          localAddr
+	keepalive      bool
+	resolvers      csl
+	unixSocket     string
 }
 
 // attack validates the attack arguments, sets up the
@@ -179,6 +181,7 @@ func attack(opts *attackOpts) (err error) {
 		vegeta.MaxWorkers(opts.maxWorkers),
 		vegeta.KeepAlive(opts.keepalive),
 		vegeta.Connections(opts.connections),
+		vegeta.MaxConnections(opts.maxConnections),
 		vegeta.HTTP2(opts.http2),
 		vegeta.H2C(opts.h2c),
 		vegeta.MaxBody(opts.maxBody),

--- a/lib/attack.go
+++ b/lib/attack.go
@@ -41,6 +41,9 @@ const (
 	// DefaultConnections is the default amount of max open idle connections per
 	// target host.
 	DefaultConnections = 10000
+	// DefaultMaxConnections is the default amount of connections per target
+	// host.
+	DefaultMaxConnections = 0
 	// DefaultWorkers is the default initial number of workers used to carry an attack.
 	DefaultWorkers = 10
 	// DefaultMaxWorkers is the default maximum number of workers used to carry an attack.
@@ -82,6 +85,7 @@ func NewAttacker(opts ...func(*Attacker)) *Attacker {
 			Dial:                a.dialer.Dial,
 			TLSClientConfig:     DefaultTLSConfig,
 			MaxIdleConnsPerHost: DefaultConnections,
+			MaxConnsPerHost:     DefaultMaxConnections,
 		},
 	}
 
@@ -111,6 +115,15 @@ func Connections(n int) func(*Attacker) {
 	return func(a *Attacker) {
 		tr := a.client.Transport.(*http.Transport)
 		tr.MaxIdleConnsPerHost = n
+	}
+}
+
+// MaxConnections returns a functional option which sets the number of maximum
+// connections per target host.
+func MaxConnections(n int) func(*Attacker) {
+	return func(a *Attacker) {
+		tr := a.client.Transport.(*http.Transport)
+		tr.MaxConnsPerHost = n
 	}
 }
 


### PR DESCRIPTION
The connections option is misleading, as it let you think that no more
than the given number of connections will be established during the
attack, whereas it does only control the maximum amount of idle connection
in the pool, but keep the maximum number of connection unlimited.

The max-connection sets the maximum number of connections per target
host, which is what most people certainly expect the connections option
does.

#### Background

<!-- Required background information to understand the PR. Link here any related issues. -->

#### Checklist

- [ ] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] Each Git commit represents meaningful milestones or atomic units of work.
- [ ] Changed or added code is covered by appropriate tests.
