### PR TITLE
Bump golang to v1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,13 @@ language: go
 services:
   - docker
 go:
-  - 1.13.x
+  - 1.14.x
+
 install:
   - go get -v golang.org/x/lint/golint
   - go get -d -t -v ./...
   - go build -v ./...
+
 jobs:
   include:
     - stage: Test

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tsenart/vegeta/v12
 
-go 1.13
+go 1.14
 
 require (
 	github.com/alecthomas/jsonschema v0.0.0-20180308105923-f2c93856175a


### PR DESCRIPTION
#### Background

Bump golang to the latest go release, v1.14.1

#### Checklist

- [x] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] Each Git commit represents meaningful milestones or atomic units of work.
- [x] Changed or added code is covered by appropriate tests.

---

relates to https://github.com/Homebrew/homebrew-core/pull/52090