### PR TITLE
fix: fix module import path for example

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,7 +762,7 @@ import (
   "fmt"
   "time"
 
-  vegeta "github.com/tsenart/vegeta/v12/lib"
+  vegeta "github.com/tsenart/vegeta/lib"
 )
 
 func main() {


### PR DESCRIPTION

#### Background

When I try to run the example code, got a import error.
I can't find the v12 in lib forder in repository, after remove /v12 in path, it works.


#### Checklist

- [x] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] Each Git commit represents meaningful milestones or atomic units of work.
- [x] Changed or added code is covered by appropriate tests.
