### PR TITLE
Added default first hist bucket if needed

### DIFF
--- a/lib/histogram.go
+++ b/lib/histogram.go
@@ -68,10 +68,14 @@ func (bs *Buckets) UnmarshalText(value []byte) error {
 	if len(value) < 2 || value[0] != '[' || value[len(value)-1] != ']' {
 		return fmt.Errorf("bad buckets: %s", value)
 	}
-	for _, v := range strings.Split(string(value[1:len(value)-1]), ",") {
+	for i, v := range strings.Split(string(value[1:len(value)-1]), ",") {
 		d, err := time.ParseDuration(strings.TrimSpace(v))
 		if err != nil {
 			return err
+		}
+		// add a default range of [0-Buckets[0]) if needed
+		if i == 0 && d > 0 {
+			*bs = append(*bs, 0)
 		}
 		*bs = append(*bs, d)
 	}

--- a/lib/histogram_test.go
+++ b/lib/histogram_test.go
@@ -57,6 +57,7 @@ func TestBuckets_UnmarshalText(t *testing.T) {
 		"[0,5ms]":             {0, 5 * time.Millisecond},
 		"[0, 5ms]":            {0, 5 * time.Millisecond},
 		"[   0,5ms, 10m    ]": {0, 5 * time.Millisecond, 10 * time.Minute},
+		"[3ms,10ms]":          {0, 3 * time.Millisecond, 10 * time.Millisecond},
 	} {
 		var got Buckets
 		if err := got.UnmarshalText([]byte(value)); err != nil {


### PR DESCRIPTION
#### Background

Fixes #522

When reporting `hist` with buckets that doesn't start with 0, any requests that won't fit the first bucket will fall into the *last* bucket, skewing the results. Please see discussion in issue #522 . 

This PR will check if the first bucket starts with 0. If not, it will create a default bucket for such cases. For example, this input
`-hist[5ms,10ms,1s]` will generate the following buckets: `[0,5ms], [5ms,10ms], [10ms,1s], [1s,+Inf]` (and not `[5ms,10ms], [10ms,1s], [1s,+Inf]`)


<!-- Required background information to understand the PR. Link here any related issues. -->

#### Checklist

- [X] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [X] Each Git commit represents meaningful milestones or atomic units of work.
- [X] Changed or added code is covered by appropriate tests.
