### PR TITLE
Add support for TLS session resumption using session tickets

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ attack command:
     	List of addresses (ip:port) to use for DNS resolution. Disables use of local system DNS. (comma separated list)
   -root-certs value
     	TLS root certificate files (comma separated list)
-  - sessiontickets
+  - session-tickets
       Enable TLS session resumption support using session tickets (default false)
   -targets string
     	Targets file (default "stdin")
@@ -353,7 +353,7 @@ the ones configured by the operating system. Works only on non Windows systems.
 Specifies the trusted TLS root CAs certificate files as a comma separated
 list. If unspecified, the default system CAs certificates will be used.
 
-#### `-sessiontickets`
+#### `-session-tickets`
 
 Specifies whether to support TLS session resumption using session tickets.
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ attack command:
     	List of addresses (ip:port) to use for DNS resolution. Disables use of local system DNS. (comma separated list)
   -root-certs value
     	TLS root certificate files (comma separated list)
+  - sessiontickets
+      Enable session resumption using session tickets (default false)
   -targets string
     	Targets file (default "stdin")
   -timeout duration
@@ -350,6 +352,10 @@ the ones configured by the operating system. Works only on non Windows systems.
 
 Specifies the trusted TLS root CAs certificate files as a comma separated
 list. If unspecified, the default system CAs certificates will be used.
+
+#### `-sessiontickets`
+
+Specifies whether to support session resumption using session tickets.
 
 #### `-targets`
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ attack command:
   -root-certs value
     	TLS root certificate files (comma separated list)
   - sessiontickets
-      Enable session resumption support using session tickets (default false)
+      Enable TLS session resumption support using session tickets (default false)
   -targets string
     	Targets file (default "stdin")
   -timeout duration
@@ -355,7 +355,7 @@ list. If unspecified, the default system CAs certificates will be used.
 
 #### `-sessiontickets`
 
-Specifies whether to support session resumption using session tickets.
+Specifies whether to support TLS session resumption using session tickets.
 
 #### `-targets`
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ attack command:
   -root-certs value
     	TLS root certificate files (comma separated list)
   - sessiontickets
-      Enable session resumption using session tickets (default false)
+      Enable session resumption support using session tickets (default false)
   -targets string
     	Targets file (default "stdin")
   -timeout duration

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ attack command:
     	List of addresses (ip:port) to use for DNS resolution. Disables use of local system DNS. (comma separated list)
   -root-certs value
     	TLS root certificate files (comma separated list)
-  - session-tickets
+  -session-tickets
       Enable TLS session resumption support using session tickets (default false)
   -targets string
     	Targets file (default "stdin")

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ attack command:
   -root-certs value
     	TLS root certificate files (comma separated list)
   -session-tickets
-      Enable TLS session resumption support using session tickets (default false)
+    	Enable TLS session resumption support using session tickets (default false)
   -targets string
     	Targets file (default "stdin")
   -timeout duration

--- a/attack.go
+++ b/attack.go
@@ -56,6 +56,7 @@ func attackCmd() command {
 	fs.Var(&opts.laddr, "laddr", "Local IP address")
 	fs.BoolVar(&opts.keepalive, "keepalive", true, "Use persistent connections")
 	fs.StringVar(&opts.unixSocket, "unix-socket", "", "Connect over a unix socket. This overrides the host address in target URLs")
+	fs.BoolVar(&opts.sessionTickets, "sessiontickets", false, "Use session tickets")
 	systemSpecificFlags(fs, opts)
 
 	return command{fs, func(args []string) error {
@@ -99,6 +100,7 @@ type attackOpts struct {
 	keepalive      bool
 	resolvers      csl
 	unixSocket     string
+  sessionTickets bool
 }
 
 // attack validates the attack arguments, sets up the
@@ -188,6 +190,7 @@ func attack(opts *attackOpts) (err error) {
 		vegeta.UnixSocket(opts.unixSocket),
 		vegeta.ProxyHeader(proxyHdr),
 		vegeta.ChunkedBody(opts.chunked),
+    vegeta.SessionTickets(opts.sessionTickets),
 	)
 
 	res := atk.Attack(tr, opts.rate, opts.duration, opts.name)

--- a/attack.go
+++ b/attack.go
@@ -56,7 +56,7 @@ func attackCmd() command {
 	fs.Var(&opts.laddr, "laddr", "Local IP address")
 	fs.BoolVar(&opts.keepalive, "keepalive", true, "Use persistent connections")
 	fs.StringVar(&opts.unixSocket, "unix-socket", "", "Connect over a unix socket. This overrides the host address in target URLs")
-	fs.BoolVar(&opts.sessionTickets, "sessiontickets", false, "Support session resumption using session tickets")
+	fs.BoolVar(&opts.sessionTickets, "sessiontickets", false, "Support TLS session resumption using session tickets")
 	systemSpecificFlags(fs, opts)
 
 	return command{fs, func(args []string) error {

--- a/attack.go
+++ b/attack.go
@@ -56,7 +56,7 @@ func attackCmd() command {
 	fs.Var(&opts.laddr, "laddr", "Local IP address")
 	fs.BoolVar(&opts.keepalive, "keepalive", true, "Use persistent connections")
 	fs.StringVar(&opts.unixSocket, "unix-socket", "", "Connect over a unix socket. This overrides the host address in target URLs")
-	fs.BoolVar(&opts.sessionTickets, "sessiontickets", false, "Use session tickets")
+	fs.BoolVar(&opts.sessionTickets, "sessiontickets", false, "Support session resumption using session tickets")
 	systemSpecificFlags(fs, opts)
 
 	return command{fs, func(args []string) error {

--- a/attack.go
+++ b/attack.go
@@ -56,7 +56,7 @@ func attackCmd() command {
 	fs.Var(&opts.laddr, "laddr", "Local IP address")
 	fs.BoolVar(&opts.keepalive, "keepalive", true, "Use persistent connections")
 	fs.StringVar(&opts.unixSocket, "unix-socket", "", "Connect over a unix socket. This overrides the host address in target URLs")
-	fs.BoolVar(&opts.sessionTickets, "sessiontickets", false, "Support TLS session resumption using session tickets")
+	fs.BoolVar(&opts.sessionTickets, "session-tickets", false, "Support TLS session resumption using session tickets")
 	systemSpecificFlags(fs, opts)
 
 	return command{fs, func(args []string) error {
@@ -100,7 +100,7 @@ type attackOpts struct {
 	keepalive      bool
 	resolvers      csl
 	unixSocket     string
-  sessionTickets bool
+	sessionTickets bool
 }
 
 // attack validates the attack arguments, sets up the
@@ -190,7 +190,7 @@ func attack(opts *attackOpts) (err error) {
 		vegeta.UnixSocket(opts.unixSocket),
 		vegeta.ProxyHeader(proxyHdr),
 		vegeta.ChunkedBody(opts.chunked),
-    vegeta.SessionTickets(opts.sessionTickets),
+		vegeta.SessionTickets(opts.sessionTickets),
 	)
 
 	res := atk.Attack(tr, opts.rate, opts.duration, opts.name)

--- a/lib/attack.go
+++ b/lib/attack.go
@@ -246,7 +246,7 @@ func UnixSocket(socket string) func(*Attacker) {
 }
 
 // SessionTickets returns a functional option which configures usage of session
-// tickets for session resumption.
+// tickets for TLS session resumption.
 func SessionTickets(sessiontickets bool) func(*Attacker) {
   return func(a *Attacker) {
     if sessiontickets {

--- a/lib/attack.go
+++ b/lib/attack.go
@@ -245,6 +245,18 @@ func UnixSocket(socket string) func(*Attacker) {
 	}
 }
 
+// SessionTickets returns a functional option which configures usage of session
+// tickets for session resumption.
+func SessionTickets(sessiontickets bool) func(*Attacker) {
+  return func(a *Attacker) {
+    if sessiontickets {
+		  cf := a.client.Transport.(*http.Transport).TLSClientConfig
+      cf.SessionTicketsDisabled = false
+      cf.ClientSessionCache = tls.NewLRUClientSessionCache(0)
+    }
+  }
+}
+
 // Client returns a functional option that allows you to bring your own http.Client
 func Client(c *http.Client) func(*Attacker) {
 	return func(a *Attacker) { a.client = *c }

--- a/lib/attack.go
+++ b/lib/attack.go
@@ -250,7 +250,7 @@ func UnixSocket(socket string) func(*Attacker) {
 func SessionTickets(sessiontickets bool) func(*Attacker) {
   return func(a *Attacker) {
     if sessiontickets {
-		  cf := a.client.Transport.(*http.Transport).TLSClientConfig
+      cf := a.client.Transport.(*http.Transport).TLSClientConfig
       cf.SessionTicketsDisabled = false
       cf.ClientSessionCache = tls.NewLRUClientSessionCache(0)
     }

--- a/lib/attack.go
+++ b/lib/attack.go
@@ -247,14 +247,14 @@ func UnixSocket(socket string) func(*Attacker) {
 
 // SessionTickets returns a functional option which configures usage of session
 // tickets for TLS session resumption.
-func SessionTickets(sessiontickets bool) func(*Attacker) {
-  return func(a *Attacker) {
-    if sessiontickets {
-      cf := a.client.Transport.(*http.Transport).TLSClientConfig
-      cf.SessionTicketsDisabled = false
-      cf.ClientSessionCache = tls.NewLRUClientSessionCache(0)
-    }
-  }
+func SessionTickets(enabled bool) func(*Attacker) {
+	return func(a *Attacker) {
+		if enabled {
+			cf := a.client.Transport.(*http.Transport).TLSClientConfig
+			cf.SessionTicketsDisabled = false
+			cf.ClientSessionCache = tls.NewLRUClientSessionCache(0)
+		}
+	}
 }
 
 // Client returns a functional option that allows you to bring your own http.Client

--- a/lib/attack_test.go
+++ b/lib/attack_test.go
@@ -165,15 +165,15 @@ func TestKeepAlive(t *testing.T) {
 // This test cannot be run in parallel with TestTLSConfig() because ClientSessionCache
 // is designed to be called concurrently from different goroutines.
 func TestSessionTickets(t *testing.T) {
-  atk := NewAttacker(SessionTickets(true))
-  cf := atk.client.Transport.(*http.Transport).TLSClientConfig
-  got, want := cf.SessionTicketsDisabled, false
-  if got != want {
-    t.Fatalf("got: %v, want: %v", got, want)
-  }
-  if cf.ClientSessionCache == nil {
-    t.Fatalf("ClientSessionCache is nil")
-  }
+	atk := NewAttacker(SessionTickets(true))
+	cf := atk.client.Transport.(*http.Transport).TLSClientConfig
+	got, want := cf.SessionTicketsDisabled, false
+	if got != want {
+		t.Fatalf("got: %v, want: %v", got, want)
+	}
+	if cf.ClientSessionCache == nil {
+		t.Fatalf("ClientSessionCache is nil")
+	}
 }
 
 func TestConnections(t *testing.T) {

--- a/lib/attack_test.go
+++ b/lib/attack_test.go
@@ -62,7 +62,6 @@ func TestAttackDuration(t *testing.T) {
 	}
 }
 
-// Cannot be run concurrently with TestSessionTickets()
 func TestTLSConfig(t *testing.T) {
 	atk := NewAttacker()
 	got := atk.client.Transport.(*http.Transport).TLSClientConfig

--- a/lib/attack_test.go
+++ b/lib/attack_test.go
@@ -62,8 +62,8 @@ func TestAttackDuration(t *testing.T) {
 	}
 }
 
+// Cannot be run concurrently with TestSessionTickets()
 func TestTLSConfig(t *testing.T) {
-	t.Parallel()
 	atk := NewAttacker()
 	got := atk.client.Transport.(*http.Transport).TLSClientConfig
 	if want := (&tls.Config{InsecureSkipVerify: true}); !reflect.DeepEqual(got, want) {
@@ -161,6 +161,20 @@ func TestKeepAlive(t *testing.T) {
 	if want := true; got != want {
 		t.Fatalf("got: %v, want: %v", got, want)
 	}
+}
+
+// This test cannot be run in parallel with TestTLSConfig() because ClientSessionCache
+// is designed to be called concurrently from different goroutines.
+func TestSessionTickets(t *testing.T) {
+  atk := NewAttacker(SessionTickets(true))
+  cf := atk.client.Transport.(*http.Transport).TLSClientConfig
+  got, want := cf.SessionTicketsDisabled, false
+  if got != want {
+    t.Fatalf("got: %v, want: %v", got, want)
+  }
+  if cf.ClientSessionCache == nil {
+    t.Fatalf("ClientSessionCache is nil")
+  }
 }
 
 func TestConnections(t *testing.T) {


### PR DESCRIPTION
#### Background

Hello, vegeta is used by my team for HTTP(s) performance testing. Recently, I needed to test the performance improvements of TLS session resumption using session tickets, but wasn't able to find a good HTTP benchmarking tool that supported it. So, I thought that this would be a good feature to add to vegeta.

I have manually tested the feature, added a test for it, and updated the README.