### PR TITLE
Fix incorrect `-timeout`  documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,8 +358,7 @@ See the [`-format`](#-format) section to learn about the different target format
 
 #### `-timeout`
 
-Specifies the timeout for each request. The default is 0 which disables
-timeouts.
+Specifies the timeout for each request. The default is 30s. Setting a timeout of 0 disables timeout.
 
 #### `-workers`
 


### PR DESCRIPTION
#### Background

Under `Usage Manual`, the helptext from the vegeta attack command describes 
timeout to be 30s by default (which I've also observed in practice), but further 
down the documentation says it's 0 by default.

This PR updates that documentation.

#### Checklist

- [X] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [X] Each Git commit represents meaningful milestones or atomic units of work.
- [X] Changed or added code is covered by appropriate tests.
