### PR TITLE
Fix typo Github to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Both the library and the CLI are versioned with [SemVer v2.0.0](https://semver.o
 After [v8.0.0](https://github.com/tsenart/vegeta/tree/v8.0.0), the two components
 are versioned separately to better isolate breaking changes to each.
 
-CLI releases are tagged with `cli/vMAJOR.MINOR.PATCH` and published on the [Github releases page](https://github.com/tsenart/vegeta/releases).
+CLI releases are tagged with `cli/vMAJOR.MINOR.PATCH` and published on the [GitHub releases page](https://github.com/tsenart/vegeta/releases).
 As for the library, new versions are tagged with both `lib/vMAJOR.MINOR.PATCH` and `vMAJOR.MINOR.PATCH`.
 The latter tag is required for compatibility with `go mod`.
 


### PR DESCRIPTION
#### Background

I was reading the doc and found this typo.

#### Checklist

- [x] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] Each Git commit represents meaningful milestones or atomic units of work.
- [x] Changed or added code is covered by appropriate tests.
