### PR TITLE
Set body to nil when request is GET

### DIFF
--- a/lib/targets.go
+++ b/lib/targets.go
@@ -31,9 +31,12 @@ type Target struct {
 // Request creates an *http.Request out of Target and returns it along with an
 // error in case of failure.
 func (t *Target) Request() (*http.Request, error) {
-	req, err := http.NewRequest(t.Method, t.URL, bytes.NewReader(t.Body))
+	req, err := http.NewRequest(t.Method, t.URL, nil)
 	if err != nil {
 		return nil, err
+	}
+	if req.Method != http.MethodGet {
+		req.Body = ioutil.NopCloser(bytes.NewReader(t.Body))
 	}
 	for k, vs := range t.Header {
 		req.Header[k] = make([]string, len(vs))

--- a/lib/targets_test.go
+++ b/lib/targets_test.go
@@ -23,7 +23,7 @@ func TestTargetRequest(t *testing.T) {
 	}
 
 	tgt := Target{
-		Method: "GET",
+		Method: "POST",
 		URL:    "http://:9999/",
 		Body:   body,
 		Header: http.Header{
@@ -42,6 +42,38 @@ func TestTargetRequest(t *testing.T) {
 
 	if !bytes.Equal(tgt.Body, reqBody) {
 		t.Fatalf("Target body wasn't copied correctly")
+	}
+
+	tgt.Header.Set("X-Stuff", "0")
+	if req.Header.Get("X-Stuff") == "0" {
+		t.Error("Each Target must have its own Header")
+	}
+
+	want, got := tgt.Header.Get("Host"), req.Header.Get("Host")
+	if want != got {
+		t.Fatalf("Target Header wasn't copied correctly. Want: %s, Got: %s", want, got)
+	}
+	if req.Host != want {
+		t.Fatalf("Target Host wasn't copied correctly. Want: %s, Got: %s", want, req.Host)
+	}
+}
+func TestTargetGETRequest(t *testing.T) {
+	t.Parallel()
+
+	tgt := Target{
+		Method: "GET",
+		URL:    "http://:9999/",
+		Body:   nil,
+		Header: http.Header{
+			"X-Some-Header":       []string{"1"},
+			"X-Some-Other-Header": []string{"2"},
+			"X-Some-New-Header":   []string{"3"},
+			"Host":                []string{"lolcathost"},
+		},
+	}
+	req, _ := tgt.Request()
+	if req.Body != nil {
+		t.Fatal("Body should be nil for GET requests")
 	}
 
 	tgt.Header.Set("X-Stuff", "0")


### PR DESCRIPTION
Update test scenarios

Signed-off-by: Vicente Zepeda Mas <vzepedam@redhat.com>

#### Background

`vegeta` Targeter always sets a body, even if it was set to nil, for any type of requests.

Some APIs have strong restrictions and fail when encountering a body in `GET` request.

Fix #556 

#### Checklist

- [x] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] Each Git commit represents meaningful milestones or atomic units of work.
- [x] Changed or added code is covered by appropriate tests.
