### PR TITLE
feat: adding a new param to show url with status code errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ report command:
     	Output file (default "stdout")
   -type string
     	Report type to generate [text, json, hist[buckets], hdrplot] (default "text")
+  -verbose boolean
+      Show all requests with status code errors (default false)
 
 examples:
   echo "GET http://localhost/" | vegeta attack -duration=5s | tee results.bin | vegeta report

--- a/lib/metrics.go
+++ b/lib/metrics.go
@@ -38,6 +38,8 @@ type Metrics struct {
 	Success float64 `json:"success"`
 	// StatusCodes is a histogram of the responses' status codes.
 	StatusCodes map[string]int `json:"status_codes"`
+	// RequestsErrors is a requests error (400+ ~ 600-).
+	RequestsErrors []string `json:"requests_errors"`
 	// Errors is a set of unique errors returned by the targets during the attack.
 	Errors []string `json:"errors"`
 
@@ -49,7 +51,6 @@ type Metrics struct {
 // Result to Metrics.
 func (m *Metrics) Add(r *Result) {
 	m.init()
-
 	m.Requests++
 	m.StatusCodes[strconv.Itoa(int(r.Code))]++
 	m.BytesOut.Total += r.BytesOut
@@ -71,6 +72,11 @@ func (m *Metrics) Add(r *Result) {
 
 	if r.Code >= 200 && r.Code < 400 {
 		m.success++
+	}
+
+	if r.Code >= 400 && r.Code < 600 {
+		var codeWithURL string = "Code: " + strconv.Itoa(int(r.Code)) + " - " + r.URL
+		m.RequestsErrors = append(m.RequestsErrors, codeWithURL)
 	}
 
 	if r.Error != "" {

--- a/lib/reporters.go
+++ b/lib/reporters.go
@@ -54,7 +54,7 @@ func NewHistogramReporter(h *Histogram) Reporter {
 
 // NewTextReporter returns a Reporter that writes out Metrics as aligned,
 // formatted text.
-func NewTextReporter(m *Metrics) Reporter {
+func NewTextReporter(m *Metrics, verbose bool) Reporter {
 	const fmtstr = "Requests\t[total, rate, throughput]\t%d, %.2f, %.2f\n" +
 		"Duration\t[total, attack, wait]\t%s, %s, %s\n" +
 		"Latencies\t[min, mean, 50, 90, 95, 99, max]\t%s, %s, %s, %s, %s, %s, %s\n" +
@@ -64,7 +64,7 @@ func NewTextReporter(m *Metrics) Reporter {
 		"Status Codes\t[code:count]\t"
 
 	return func(w io.Writer) (err error) {
-		tw := tabwriter.NewWriter(w, 0, 8, 2, ' ', tabwriter.StripEscape)
+		tw := tabwriter.NewWriter(w, 0, 9, 2, ' ', tabwriter.StripEscape)
 		if _, err = fmt.Fprintf(tw, fmtstr,
 			m.Requests, m.Rate, m.Throughput,
 			round(m.Duration+m.Wait),
@@ -100,6 +100,12 @@ func NewTextReporter(m *Metrics) Reporter {
 
 		if _, err = fmt.Fprintln(tw, "\nError Set:"); err != nil {
 			return err
+		}
+
+		if verbose {
+			for _, request := range m.RequestsErrors {
+				fmt.Fprintln(tw, "\n"+request)
+			}
 		}
 
 		for _, e := range m.Errors {


### PR DESCRIPTION
#### Background

Adding parameter -verbose in report to show all request errors between 400 and 600.

#### Checklist

- [x] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] Each Git commit represents meaningful milestones or atomic units of work.
- [ ] Changed or added code is covered by appropriate tests.
