### PR TITLE
Add Stop() call in library example

### DIFF
--- a/README.md
+++ b/README.md
@@ -786,6 +786,8 @@ func main() {
     metrics.Add(res)
   }
   metrics.Close()
+  
+  attacker.Stop()
 
   fmt.Printf("99th percentile: %s\n", metrics.Latencies.P99)
 }


### PR DESCRIPTION
The `stopch` is never closed in a regular usage, that cause a channel leak.

#### Background

I've wrapped `vegeta` in a [HTTP server](https://github.com/ViBiOh/vegetaas) to be used with Flagger for load-testing when doing canary deployment.

I've seen a goroutine leak (vertical dash mean a deployment and so an attack call). At the right of graph, it's a fixed version with a call to `Stop()`

![Screen Shot 2021-05-29 at 7 16 47 PM](https://user-images.githubusercontent.com/2349470/120079074-9c10f200-c0b2-11eb-8147-225adcbfeee9.png)

#### Checklist

- [x] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] Each Git commit represents meaningful milestones or atomic units of work.
- [x] Changed or added code is covered by appropriate tests.
