### PR TITLE
Add feat to import files in body

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,29 @@ PATCH http://goku:9090/thing/71988591
 @/path/to/thing-71988591.json
 ```
 
+###### Targets with formdata body
+
+target.req
+```
+POST http://goku:9090/things
+@/path/to/formdata.txt
+```
+
+formdata.txt
+```
+------WebKitFormBoundary
+Content-Disposition: form-data; name="report"; filename="spec.pdf"
+Content-Type: application/pdf
+
+@spec.pdf
+
+------WebKitFormBoundary
+Content-Disposition: form-data; name="powerlevel"
+
+9000
+------WebKitFormBoundary--
+```
+
 ###### Targets with custom bodies and headers
 
 ```


### PR DESCRIPTION
'@' is checked in body file, and replaced with binary of another file

#### Background

Testing file upload via multipart/form-data is really hard with vegeta. Usually requires us to paste the binary in the body.txt file.
Issues related to this:
https://github.com/tsenart/vegeta/issues/572
https://github.com/tsenart/vegeta/issues/347
https://github.com/tsenart/vegeta/issues/135

#### Checklist

- [X] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [X] Each Git commit represents meaningful milestones or atomic units of work.
- [ ] Changed or added code is covered by appropriate tests.

I have updated documentation for the same.