### PR TITLE
disable the http2 attempt upgrade when http2 set to false

### DIFF
--- a/lib/attack.go
+++ b/lib/attack.go
@@ -208,6 +208,7 @@ func HTTP2(enabled bool) func(*Attacker) {
 		if tr := a.client.Transport.(*http.Transport); enabled {
 			http2.ConfigureTransport(tr)
 		} else {
+			tr.ForceAttemptHTTP2 = false
 			tr.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
 		}
 	}


### PR DESCRIPTION
#### Background
Even we disable the http2 from command line by set `-http2=false`, vegeta will still try to attempt http2 upgrade. So, when server ALPN contains h2 support, vegeta will finally still use the http2 connection to server. This fully prevents the user from testing http1.1 protocol when server ALPN support both http1.1 + h2. 

This is very common case when server is using istio as a proxy, since istio always enable ALPN with http1.1 + h2 support. So there is no way to use vegeta to test istio based server with http 1.1 protocol

### Solution
Based on https://go.dev/src/net/http/transport.go, this is because the go transport library default try to enable `ForceAttemptHTTP2`, so we should disable it when user set `-http2=false` from command line to ensure http1.1 only.

```
	// ForceAttemptHTTP2 controls whether HTTP/2 is enabled when a non-zero
	// Dial, DialTLS, or DialContext func or TLSClientConfig is provided.
	// By default, use of any those fields conservatively disables HTTP/2.
	// To use a custom dialer or TLS config and still attempt HTTP/2
	// upgrades, set this to true.
	ForceAttemptHTTP2 bool
```


