### PR TITLE
Fix: use print-style function

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -59,7 +59,7 @@ func encodeCmd() command {
 	output := fs.String("output", "stdout", "Output file")
 
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, encodeUsage)
+		fmt.Fprint(os.Stderr, encodeUsage)
 	}
 
 	return command{fs, func(args []string) error {

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func main() {
 			}
 		}
 
-		fmt.Fprintln(fs.Output(), examples)
+		fmt.Fprint(fs.Output(), examples)
 	}
 
 	fs.Parse(os.Args[1:])

--- a/plot.go
+++ b/plot.go
@@ -47,7 +47,7 @@ func plotCmd() command {
 	output := fs.String("output", "stdout", "Output file")
 
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, plotUsage)
+		fmt.Fprint(os.Stderr, plotUsage)
 	}
 
 	return command{fs, func(args []string) error {

--- a/report.go
+++ b/report.go
@@ -44,7 +44,7 @@ func reportCmd() command {
 	buckets := fs.String("buckets", "", "Histogram buckets, e.g.: \"[0,1ms,10ms]\"")
 
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, reportUsage)
+		fmt.Fprint(os.Stderr, reportUsage)
 	}
 
 	return command{fs, func(args []string) error {


### PR DESCRIPTION
#### Background
When I used `vscode` to run `TestHeadersSet` in the `attack_test.go` file, he failed the test and told me `fmt.Fprintln arg list ends with redundant newline`, I queried stackoverflow(https://stackoverflow.com/questions/71052339/what-does-printf-style-function-with-dynamic-format-string-and-no-further-argum) and made the following changes

#### Checklist

- [x] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] Each Git commit represents meaningful milestones or atomic units of work.
- [ ] Changed or added code is covered by appropriate tests.
