### PR TITLE
Update default -timeout value in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,8 +358,7 @@ See the [`-format`](#-format) section to learn about the different target format
 
 #### `-timeout`
 
-Specifies the timeout for each request. The default is 0 which disables
-timeouts.
+Specifies the timeout for each request. A value of `0` disables timeouts.
 
 #### `-workers`
 


### PR DESCRIPTION
#### Background

The default value of the `-timeout` flag in the README differs from the actual value of `30s`.

#### Checklist

- [x] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] Each Git commit represents meaningful milestones or atomic units of work.
- [x] Changed or added code is covered by appropriate tests. (not applicable)