### PR TITLE
fix warning by removing redundant new line

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func main() {
 			}
 		}
 
-		fmt.Fprintln(fs.Output(), examples)
+		fmt.Fprint(fs.Output(), examples)
 	}
 
 	fs.Parse(os.Args[1:])


### PR DESCRIPTION
`fmt.Fprintln(fs.Output(), examples)`
There was warning for above code which said 
> fmt.Fprintln arg list ends with redundant newline

by replacing FprintLn to Fprint warning fixed
 