### PR TITLE
Add optional feature to set the SO_REUSEADDR option before binding th…

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ attack command:
     	Number of redirects to follow. -1 will not follow but marks as success (default 10)
   -resolvers value
     	List of addresses (ip:port) to use for DNS resolution. Disables use of local system DNS. (comma separated list)
+  -reuseaddr
+    	Set the SO_REUSEADDR socket option (default false)
   -root-certs value
     	TLS root certificate files (comma separated list)
   -session-tickets
@@ -391,6 +393,12 @@ the response is marked as successful.
 
 Specifies custom DNS resolver addresses to use for name resolution instead of
 the ones configured by the operating system. Works only on non Windows systems.
+
+#### `-resolvers`
+
+Specifies whether to set the SO_REUSEADDR option on the TCP socket before binding
+it. Can reduce the amount of "bind: address already in use" errors when doing many
+connections to the same server and port combination.
 
 #### `-root-certs`
 

--- a/attack.go
+++ b/attack.go
@@ -62,6 +62,7 @@ func attackCmd() command {
 	fs.StringVar(&opts.promAddr, "prometheus-addr", "", "Prometheus exporter listen address [empty = disabled]. Example: 0.0.0.0:8880")
 	fs.Var(&dnsTTLFlag{&opts.dnsTTL}, "dns-ttl", "Cache DNS lookups for the given duration [-1 = disabled, 0 = forever]")
 	fs.BoolVar(&opts.sessionTickets, "session-tickets", false, "Enable TLS session resumption using session tickets")
+	fs.BoolVar(&opts.reuseaddr, "reuseaddr", false, "Set the SO_REUSEADDR socket option (default false)")
 	systemSpecificFlags(fs, opts)
 
 	return command{fs, func(args []string) error {
@@ -108,6 +109,7 @@ type attackOpts struct {
 	promAddr       string
 	dnsTTL         time.Duration
 	sessionTickets bool
+	reuseaddr      bool
 }
 
 // attack validates the attack arguments, sets up the
@@ -219,6 +221,7 @@ func attack(opts *attackOpts) (err error) {
 		vegeta.ChunkedBody(opts.chunked),
 		vegeta.DNSCaching(opts.dnsTTL),
 		vegeta.SessionTickets(opts.sessionTickets),
+		vegeta.Reuseaddr(opts.reuseaddr),
 	)
 
 	res := atk.Attack(tr, opts.rate, opts.duration, opts.name)


### PR DESCRIPTION
Add an optional parameter to set the SO_REUSEADDR option on the TCP socket before binding
it (default false). Can reduce the amount of "bind: address already in use" errors when doing many
connections to the same server and port combination, like the ones that happened on https://github.com/tsenart/vegeta/issues/583.