### PR TITLE
all: remove leftover use of deprecated ioutil

### DIFF
--- a/lib/attack.go
+++ b/lib/attack.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"net"
@@ -541,9 +540,9 @@ func (a *Attacker) hit(tr Targeter, atk *attack) *Result {
 		body = io.LimitReader(r.Body, a.maxBody)
 	}
 
-	if res.Body, err = ioutil.ReadAll(body); err != nil {
+	if res.Body, err = io.ReadAll(body); err != nil {
 		return &res
-	} else if _, err = io.Copy(ioutil.Discard, r.Body); err != nil {
+	} else if _, err = io.Copy(io.Discard, r.Body); err != nil {
 		return &res
 	}
 


### PR DESCRIPTION
#### Background

<!-- Required background information to understand the PR. Link here any related issues. -->
ioutil is deprecated, see https://go.dev/doc/go1.16#ioutil

Follow up on #634

#### Checklist

- [x] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] Each Git commit represents meaningful milestones or atomic units of work.
- [x] Changed or added code is covered by appropriate tests.
