### PR TITLE
Remove unnecessary time.sleep(5) call in ramp-requests.py

### DIFF
--- a/scripts/load-ramping/ramp-requests.py
+++ b/scripts/load-ramping/ramp-requests.py
@@ -29,7 +29,6 @@ for rate in rates:
         cmd = 'vegeta attack -duration 5s -rate %i/1000s -output %s' % (1000*rate, filename)
         print(cmd, file=sys.stderr)
         subprocess.run(cmd, shell=True, input=target, encoding='utf-8')
-        time.sleep(5)
 
 
 # Run vegeta report, and extract data for gnuplot


### PR DESCRIPTION
#### Background


In the ramp-requests.py file, there's no clear reason for using sleep(5) after executing the subprocess.run() method for an attack. 
My guess is that when creating the process with run(), it was assumed to be non-blocking, and sleep(5) was given to match -duration 5s.
If this assumption is correct, the subprocess.run() method is blocking, and it won't execute the next command until the child process finishes, making the sleep unnecessary.
If there was an intention to add an arbitrary delay, there should be a specific comment or explanation. Otherwise, if someone assumes that subprocess.run() is non-blocking and adds time.sleep(5), it can cause confusion.

You can find more details about the blocking nature of subprocess in the following links:

- https://docs.python.org/3/library/subprocess.html#subprocess.run
- https://stackoverflow.com/questions/21936597/blocking-and-non-blocking-subprocess-calls


#### Checklist

- [x] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] Each Git commit represents meaningful milestones or atomic units of work.
- [x] Changed or added code is covered by appropriate tests.
