### PR TITLE
fix(build): Updating the output directory of the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION=$(shell git describe --tags --exact-match --always)
 DATE=$(shell date +'%FT%TZ%z')
 
 vegeta: generate
-	CGO_ENABLED=0 go build -v -a -tags=netgo \
+	CGO_ENABLED=0 go build -o ./bin/vegeta -v -a -tags=netgo \
   	-ldflags '-s -w -extldflags "-static" -X main.Version=$(VERSION) -X main.Commit=$(COMMIT) -X main.Date=$(DATE)'
 
 generate: GOARCH := $(shell go env GOHOSTARCH)


### PR DESCRIPTION
#### Background

<!-- Required background information to understand the PR. Link here any related issues. -->

In order to keep things in the repo clean and streamlined, I have moved the build of the `Makefile` to output the binary into a `bin/` subdirectory.

This prevents binaries being lost in the root of the repo and causing problems.

#### Checklist

- [x] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] Each Git commit represents meaningful milestones or atomic units of work.
- [ ] Changed or added code is covered by appropriate tests.
