### PR TITLE
Add information about the easyjson requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ $ pkg install vegeta
 ```
 
 ### Source
+When building from source you'll need to install [easyjson](https://github.com/mailru/easyjson) manually.
+
+On Debian-based systems it can be done with:
+
+```shell
+sudo apt install golang-easyjson
+```
+
+Then build vegeta like so:
 
 ```shell
 git clone https://github.com/tsenart/vegeta


### PR DESCRIPTION
Resolves #657

#### Background

Easyjson is required to build the package from source, but it's not mentioned in README, as was already reported in #657 and caused #687.

#### Checklist

- [ ] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] Each Git commit represents meaningful milestones or atomic units of work.
- [ ] Changed or added code is covered by appropriate tests.
