### PR TITLE
Add `scoop` Windows installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ $ pkg install vegeta
 
 ### Windows
 
-<a href="https://github.com/ScoopInstaller/Main/blob/master/bucket/atac.json">
-  <img src="https://repology.org/badge/version-for-repo/scoop/atac.svg" alt="Scoop package">
+<a href="https://github.com/ScoopInstaller/Main/blob/master/bucket/vegeta.json">
+  <img src="https://repology.org/badge/version-for-repo/scoop/vegeta.svg" alt="Scoop package">
 </a>
 
 ```shell


### PR DESCRIPTION
See ScoopInstaller/Main#6493

#### Background

Adds option to install `vegeta` binary on Windows using [scoop](https://scoop.sh/#/apps?q=vegeta) package manager.

#### Checklist

- [x] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] Each Git commit represents meaningful milestones or atomic units of work.
- [x] Changed or added code is covered by appropriate tests.
