### PR TITLE
Issue 734: Check that the bucket definition is strictly growing

### DIFF
--- a/lib/histogram.go
+++ b/lib/histogram.go
@@ -82,5 +82,10 @@ func (bs *Buckets) UnmarshalText(value []byte) error {
 	if len(*bs) == 0 {
 		return fmt.Errorf("bad buckets: %s", value)
 	}
+	for i := range *bs {
+		if i < len(*bs)-1 && (*bs)[i] >= (*bs)[i+1] {
+			return fmt.Errorf("bad buckets, must be growing: %s", (*bs)[i+1])
+		}
+	}
 	return nil
 }

--- a/lib/histogram_test.go
+++ b/lib/histogram_test.go
@@ -42,11 +42,14 @@ func TestHistogram_Add(t *testing.T) {
 func TestBuckets_UnmarshalText(t *testing.T) {
 	t.Parallel()
 	for value, want := range map[string]string{
-		"":       "bad buckets: ",
-		" ":      "bad buckets:  ",
-		"{0, 2}": "bad buckets: {0, 2}",
-		"[]":     `time: invalid duration ""`,
-		"[0, 2]": `time: missing unit in duration "2"`,
+		"":              "bad buckets: ",
+		" ":             "bad buckets:  ",
+		"{0, 2}":        "bad buckets: {0, 2}",
+		"[]":            `time: invalid duration ""`,
+		"[0,20ms,10ms]": "bad buckets, must be growing: 10ms",
+		"[0,2ms,2ms]":   "bad buckets, must be growing: 2ms",
+		"[0,0,2ms]":     "bad buckets, must be growing: 0s",
+		"[0, 2]":        `time: missing unit in duration "2"`,
 	} {
 		if got := (&Buckets{}).UnmarshalText([]byte(value)).Error(); got != want {
 			t.Errorf("got: %v, want: %v", got, want)


### PR DESCRIPTION
#### Background

Fixes issue 734

#### Checklist

- [x ] Git commit messages conform to [community standards](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x ] Each Git commit represents meaningful milestones or atomic units of work.
- [x ] Changed or added code is covered by appropriate tests.
