### PR TITLE
fix: replace dead javadox.com link with t-digest GitHub docs

### DIFF
--- a/lib/metrics.go
+++ b/lib/metrics.go
@@ -171,7 +171,7 @@ func (l LatencyMetrics) Quantile(nth float64) time.Duration {
 func (l *LatencyMetrics) init() {
 	if l.estimator == nil {
 		// This compression parameter value is the recommended value
-		// for normal uses as per http://javadox.com/com.tdunning/t-digest/3.0/com/tdunning/math/stats/TDigest.html
+		// for normal uses as per https://github.com/tdunning/t-digest/blob/main/docs/t-digest-paper/histo.pdf
 		l.estimator = newTdigestEstimator(100)
 	}
 }


### PR DESCRIPTION
## What

Replace the broken `javadox.com` URL in `lib/metrics.go` with a working link to the t-digest paper in the official GitHub repository.

## Why

The `javadox.com` website is no longer accessible (connection refused/server down), making the comment reference useless for developers trying to understand the compression parameter recommendation. This was reported in #731.

## How

- Changed the dead URL `http://javadox.com/com.tdunning/t-digest/3.0/com/tdunning/math/stats/TDigest.html` to `https://github.com/tdunning/t-digest/blob/main/docs/t-digest-paper/histo.pdf`
- The replacement link points to the t-digest paper PDF in the official tdunning/t-digest repository, which covers the same compression parameter recommendations originally referenced by the Javadoc

## Testing

- Verified the new URL is accessible and contains the relevant documentation about compression parameters
- No functional code changes, comment-only fix

## Checklist

- [x] Comment-only change, no logic affected
- [x] Replacement link is from the canonical t-digest repository
- [x] Fixes the dead link reported in #731